### PR TITLE
[ZEPPELIN-6228] Add the missing Reviews mailing list to the community page

### DIFF
--- a/_includes/sub-views/community/mailinglist.md
+++ b/_includes/sub-views/community/mailinglist.md
@@ -30,9 +30,11 @@ for people wanting to contribute to the project.
 * __[Commits](https://lists.apache.org/list.html?commits@zeppelin.apache.org) :__ [subscribe](mailto:commits-subscribe@zeppelin.apache.org?subject=send this email to subscribe), [unsubscribe](mailto:commits-unsubscribe@zeppelin.apache.org?subject=send this email to unsubscribe), [archives](https://lists.apache.org/list.html?commits@zeppelin.apache.org)
 <br/>
 for commit messages and patches.
+* __[Reviews](https://lists.apache.org/list.html?reviews@zeppelin.apache.org) :__ [subscribe](mailto:reviews-subscribe@zeppelin.apache.org?subject=send this email to subscribe), [unsubscribe](mailto:reviews-unsubscribe@zeppelin.apache.org?subject=send this email to unsubscribe), [archives](https://lists.apache.org/list.html?reviews@zeppelin.apache.org)
+<br/>
+for code review discussions and comments.
 
 
 ### Slack channel
 
 We also have an asf slack channel for Zeppelin, but it is not public, you can send email to the above user mail list to ask for invitation.
-


### PR DESCRIPTION
### What is this PR for?
This PR adds the Reviews mailing list section to the community page, which was missing from the documentation.

### What type of PR is it?
Documentation Update

### Todos
- [x] Add Reviews mailing list section
- [x] Test subscribe/unsubscribe/archives links

### What is the Jira issue?
[ZEPPELIN-6228]

### How should this be tested?
N/A

### Screenshots (if appropriate)
<img width="819" height="448" alt="image" src="https://github.com/user-attachments/assets/78446843-13fa-4f57-a67a-b4b3a2ec4906" />

