### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/_includes/themes/zeppelin/default.html
+++ b/_includes/themes/zeppelin/default.html
@@ -68,7 +68,17 @@
     {% endif %}
 
     <footer>
-      <!-- <p>&copy; {{ site.time | date: '%Y' }} {{ site.author.name }}</p>-->
+      <p>Copyright &copy; {{ site.time | date: '%Y' }} The Apache Software Foundation. Licensed under the <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.</p>
+      <p>Apache Zeppelin, Zeppelin, Apache, the Apache logo, and the Apache Zeppelin project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+      <p>
+        <a href="https://www.apache.org/">Foundation</a> |
+        <a href="https://www.apache.org/events/current-event.html">Events</a> |
+        <a href="https://www.apache.org/licenses/">License</a> |
+        <a href="https://www.apache.org/security/">Security</a> |
+        <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+        <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+        <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
+      </p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
The Zeppelin website is failing 6 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Foundation link (missing)
- Events (missing)
- License (missing)
- Trademarks (missing)
- Copyright (missing)
- Privacy (missing)

This replaces the empty commented-out footer with copyright, trademark attribution, and all required ASF policy links.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/