### PR TITLE
fix: satisfy ASF website policy checks via nav links and footer notices

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -55,11 +55,13 @@
         <li class="docs">
           <a href="#" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <li><a href="http://www.apache.org/foundation/how-it-works.html">Apache Software Foundation</a></li>
-            <li><a href="http://www.apache.org/licenses/">Apache License</a></li>
-            <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+            <li><a href="https://www.apache.org/">Apache Software Foundation</a></li>
+            <li><a href="https://www.apache.org/licenses/">License</a></li>
+            <li><a href="https://www.apache.org/events/current-event.html">Events</a></li>
+            <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+            <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+            <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a></li>
             <li><a href="/assets.html">Assets</a></li>
-            <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
           </ul>
         </li>
       </ul>

--- a/_includes/themes/zeppelin/default.html
+++ b/_includes/themes/zeppelin/default.html
@@ -68,7 +68,8 @@
     {% endif %}
 
     <footer>
-      <!-- <p>&copy; {{ site.time | date: '%Y' }} {{ site.author.name }}</p>-->
+      <p>Copyright &copy; {{ site.time | date: '%Y' }} The Apache Software Foundation. Licensed under the <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.</p>
+      <p>Apache Zeppelin, Zeppelin, Apache, the Apache feather logo, and the Apache Zeppelin project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The Zeppelin website fails several checks at the ASF website policy checker (https://whimsy.apache.org/site/): **Foundation, Events, License, Trademarks, Copyright, and Privacy**.

## Approach

This is an alternative to #55. Instead of adding a new footer block that duplicates the policy links, it reuses the **existing Apache navigation dropdown** and adds only the legally required notices to the footer:

- Switch the existing Apache nav links to `https://`
- Point **Foundation** at `https://www.apache.org/` (root), as the checker requires
- Rename `Apache License` → `License` so the link text matches the checker exactly
- Add the missing **Events** and **Privacy** nav links
- Add the required **Copyright** and **Trademark** notices to the footer (notices only, no link duplication)

This keeps the policy links where Zeppelin already had them (in the nav) — the same placement Apache Spark uses — and adds just two footer lines for the required legal notices.

## Verification

Verified locally with whimsy's `tools/site-scan.rb` and `SiteStandards.analyze`: all 9 policy checks (foundation, events, license, thanks, security, sponsorship, trademarks, copyright, privacy) pass. Before this change, 6 of them failed.

The `resources` check (external Twitter/widget scripts) is a separate concern and is not addressed here.