### PR TITLE
[codex] Remove external resource loads from site source

### DIFF
--- a/_includes/themes/zeppelin/default.html
+++ b/_includes/themes/zeppelin/default.html
@@ -9,13 +9,8 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
     <!-- Le styles -->
-    <link href="{{ ASSET_PATH }}/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+    <link href="{{ ASSET_PATH }}/font-awesome.min.css" rel="stylesheet">
     <link href="{{ ASSET_PATH }}/icon.css" rel="stylesheet" type="text/css"/>
     <link href="{{ ASSET_PATH }}/bootstrap/css/bootstrap.css" rel="stylesheet">
     <link href="{{ ASSET_PATH }}/css/style.css?body=1" rel="stylesheet" type="text/css">
@@ -38,7 +33,6 @@
     <!-- Js -->
     <script src="{{ ASSET_PATH }}/jquery-1.10.2.min.js"></script>
     <script src="{{ ASSET_PATH }}/angular.min.js"></script>
-<!--    <script src="https://s3.amazonaws.com/apache-zeppelin/post/medium.js"></script>-->
     <script src="{{ ASSET_PATH }}/ui-bootstrap-tpls-2.5.0.js"></script>
     <script src="{{ ASSET_PATH }}/bootstrap/js/bootstrap.min.js"></script>
     <script src="{{ ASSET_PATH }}/js/docs.js"></script>

--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -1,17 +1,8 @@
 /* Move down content because we have a fixed navbar that is 50px tall */
-/*@import url(//fonts.googleapis.com/css?family=Patua+One);*/
-/*@import url(//fonts.googleapis.com/css?family=Open+Sans);*/
-/*@import url(//fonts.googleapis.com/css?family=Raleway:300,400);*/
-
 @font-face {
   font-family: 'Patua One';
   src: url('fonts/PatuaOne-Regular.ttf') format('truetype');
 }
-
-/*@font-face {*/
-/*  font-family: 'Open Sans';*/
-/*  src: url('assets/fonts/OpenSans-Regular.ttf') format('truetype');*/
-/*}*/
 
 body {
   padding-top: 50px;

--- a/assets/themes/zeppelin/js/medium.controller.js
+++ b/assets/themes/zeppelin/js/medium.controller.js
@@ -1,7 +1,9 @@
 angular.module("app").controller("MediumCtrl", function($scope, $window, $sce) {
-  $scope.mediumPost = mediumPost
+  $scope.mediumPost = $window.mediumPost || []
 
-  var postInfo = $scope.mediumPost[0].items
+  var postInfo = $scope.mediumPost.length && $scope.mediumPost[0].items
+    ? $scope.mediumPost[0].items
+    : []
   var postInfoArray = []
 
   var init = function () {

--- a/docs/0.10.0/development/contribution/how_to_contribute_code.html
+++ b/docs/0.10.0/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/contribution/how_to_contribute_website.html
+++ b/docs/0.10.0/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/contribution/useful_developer_tools.html
+++ b/docs/0.10.0/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/helium/overview.html
+++ b/docs/0.10.0/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/helium/writing_application.html
+++ b/docs/0.10.0/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/helium/writing_spell.html
+++ b/docs/0.10.0/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/helium/writing_visualization_basic.html
+++ b/docs/0.10.0/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/helium/writing_visualization_transformation.html
+++ b/docs/0.10.0/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/development/writing_zeppelin_interpreter.html
+++ b/docs/0.10.0/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/index.html
+++ b/docs/0.10.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/alluxio.html
+++ b/docs/0.10.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/beam.html
+++ b/docs/0.10.0/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/bigquery.html
+++ b/docs/0.10.0/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/cassandra.html
+++ b/docs/0.10.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/elasticsearch.html
+++ b/docs/0.10.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/flink.html
+++ b/docs/0.10.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/geode.html
+++ b/docs/0.10.0/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/groovy.html
+++ b/docs/0.10.0/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/hazelcastjet.html
+++ b/docs/0.10.0/interpreter/hazelcastjet.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/hbase.html
+++ b/docs/0.10.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/hdfs.html
+++ b/docs/0.10.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/hive.html
+++ b/docs/0.10.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/ignite.html
+++ b/docs/0.10.0/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/influxdb.html
+++ b/docs/0.10.0/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/java.html
+++ b/docs/0.10.0/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/jdbc.html
+++ b/docs/0.10.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/jupyter.html
+++ b/docs/0.10.0/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/kotlin.html
+++ b/docs/0.10.0/interpreter/kotlin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/ksql.html
+++ b/docs/0.10.0/interpreter/ksql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/kylin.html
+++ b/docs/0.10.0/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/lens.html
+++ b/docs/0.10.0/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/livy.html
+++ b/docs/0.10.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/mahout.html
+++ b/docs/0.10.0/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/markdown.html
+++ b/docs/0.10.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/mongodb.html
+++ b/docs/0.10.0/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/neo4j.html
+++ b/docs/0.10.0/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/pig.html
+++ b/docs/0.10.0/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/postgresql.html
+++ b/docs/0.10.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/python.html
+++ b/docs/0.10.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/r.html
+++ b/docs/0.10.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/sap.html
+++ b/docs/0.10.0/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/scalding.html
+++ b/docs/0.10.0/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/scio.html
+++ b/docs/0.10.0/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/shell.html
+++ b/docs/0.10.0/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/spark.html
+++ b/docs/0.10.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/sparql.html
+++ b/docs/0.10.0/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/interpreter/submarine.html
+++ b/docs/0.10.0/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/pleasecontribute.html
+++ b/docs/0.10.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/docker.html
+++ b/docs/0.10.0/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/explore_ui.html
+++ b/docs/0.10.0/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/flink_with_zeppelin.html
+++ b/docs/0.10.0/quickstart/flink_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/install.html
+++ b/docs/0.10.0/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/kubernetes.html
+++ b/docs/0.10.0/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/python_with_zeppelin.html
+++ b/docs/0.10.0/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/r_with_zeppelin.html
+++ b/docs/0.10.0/quickstart/r_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/spark_with_zeppelin.html
+++ b/docs/0.10.0/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/sql_with_zeppelin.html
+++ b/docs/0.10.0/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/tutorial.html
+++ b/docs/0.10.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/quickstart/yarn.html
+++ b/docs/0.10.0/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/screenshots.html
+++ b/docs/0.10.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/search.html
+++ b/docs/0.10.0/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/basics/hadoop_integration.html
+++ b/docs/0.10.0/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/basics/how_to_build.html
+++ b/docs/0.10.0/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/basics/multi_user_support.html
+++ b/docs/0.10.0/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/basics/systemd.html
+++ b/docs/0.10.0/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/cdh.html
+++ b/docs/0.10.0/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/docker.html
+++ b/docs/0.10.0/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.10.0/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.10.0/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/virtual_machine.html
+++ b/docs/0.10.0/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/deployment/yarn_install.html
+++ b/docs/0.10.0/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/operation/configuration.html
+++ b/docs/0.10.0/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/operation/monitoring.html
+++ b/docs/0.10.0/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/operation/proxy_setting.html
+++ b/docs/0.10.0/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/operation/trouble_shooting.html
+++ b/docs/0.10.0/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/operation/upgrading.html
+++ b/docs/0.10.0/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/security/authentication_nginx.html
+++ b/docs/0.10.0/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/security/datasource_authorization.html
+++ b/docs/0.10.0/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/security/http_security_headers.html
+++ b/docs/0.10.0/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/security/notebook_authorization.html
+++ b/docs/0.10.0/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/security/shiro_authentication.html
+++ b/docs/0.10.0/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/setup/storage/storage.html
+++ b/docs/0.10.0/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/display_system/angular_backend.html
+++ b/docs/0.10.0/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/display_system/angular_frontend.html
+++ b/docs/0.10.0/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/display_system/basic.html
+++ b/docs/0.10.0/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/dynamic_form/intro.html
+++ b/docs/0.10.0/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/dependency_management.html
+++ b/docs/0.10.0/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/dynamic_loading.html
+++ b/docs/0.10.0/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/execution_hooks.html
+++ b/docs/0.10.0/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/installation.html
+++ b/docs/0.10.0/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.10.0/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/overview.html
+++ b/docs/0.10.0/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/interpreter/user_impersonation.html
+++ b/docs/0.10.0/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/cron_scheduler.html
+++ b/docs/0.10.0/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/customizing_homepage.html
+++ b/docs/0.10.0/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/notebook_actions.html
+++ b/docs/0.10.0/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/personalized_mode.html
+++ b/docs/0.10.0/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.10.0/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/other_features/zeppelin_context.html
+++ b/docs/0.10.0/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/configuration.html
+++ b/docs/0.10.0/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/credential.html
+++ b/docs/0.10.0/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/helium.html
+++ b/docs/0.10.0/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/interpreter.html
+++ b/docs/0.10.0/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/notebook.html
+++ b/docs/0.10.0/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/notebook_repository.html
+++ b/docs/0.10.0/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/rest_api/zeppelin_server.html
+++ b/docs/0.10.0/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.10.0/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.0/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.10.0/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/contribution/how_to_contribute_code.html
+++ b/docs/0.10.1/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/contribution/how_to_contribute_website.html
+++ b/docs/0.10.1/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/contribution/useful_developer_tools.html
+++ b/docs/0.10.1/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/helium/overview.html
+++ b/docs/0.10.1/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/helium/writing_application.html
+++ b/docs/0.10.1/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/helium/writing_spell.html
+++ b/docs/0.10.1/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/helium/writing_visualization_basic.html
+++ b/docs/0.10.1/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/helium/writing_visualization_transformation.html
+++ b/docs/0.10.1/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/development/writing_zeppelin_interpreter.html
+++ b/docs/0.10.1/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/index.html
+++ b/docs/0.10.1/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/alluxio.html
+++ b/docs/0.10.1/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/beam.html
+++ b/docs/0.10.1/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/bigquery.html
+++ b/docs/0.10.1/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/cassandra.html
+++ b/docs/0.10.1/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/elasticsearch.html
+++ b/docs/0.10.1/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/flink.html
+++ b/docs/0.10.1/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/geode.html
+++ b/docs/0.10.1/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/groovy.html
+++ b/docs/0.10.1/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/hazelcastjet.html
+++ b/docs/0.10.1/interpreter/hazelcastjet.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/hbase.html
+++ b/docs/0.10.1/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/hdfs.html
+++ b/docs/0.10.1/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/hive.html
+++ b/docs/0.10.1/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/ignite.html
+++ b/docs/0.10.1/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/influxdb.html
+++ b/docs/0.10.1/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/java.html
+++ b/docs/0.10.1/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/jdbc.html
+++ b/docs/0.10.1/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/jupyter.html
+++ b/docs/0.10.1/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/kotlin.html
+++ b/docs/0.10.1/interpreter/kotlin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/ksql.html
+++ b/docs/0.10.1/interpreter/ksql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/kylin.html
+++ b/docs/0.10.1/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/lens.html
+++ b/docs/0.10.1/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/livy.html
+++ b/docs/0.10.1/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/mahout.html
+++ b/docs/0.10.1/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/markdown.html
+++ b/docs/0.10.1/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/mongodb.html
+++ b/docs/0.10.1/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/neo4j.html
+++ b/docs/0.10.1/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/pig.html
+++ b/docs/0.10.1/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/postgresql.html
+++ b/docs/0.10.1/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/python.html
+++ b/docs/0.10.1/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/r.html
+++ b/docs/0.10.1/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/sap.html
+++ b/docs/0.10.1/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/scalding.html
+++ b/docs/0.10.1/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/scio.html
+++ b/docs/0.10.1/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/shell.html
+++ b/docs/0.10.1/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/spark.html
+++ b/docs/0.10.1/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/sparql.html
+++ b/docs/0.10.1/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/interpreter/submarine.html
+++ b/docs/0.10.1/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/pleasecontribute.html
+++ b/docs/0.10.1/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/docker.html
+++ b/docs/0.10.1/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/explore_ui.html
+++ b/docs/0.10.1/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/flink_with_zeppelin.html
+++ b/docs/0.10.1/quickstart/flink_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/install.html
+++ b/docs/0.10.1/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/kubernetes.html
+++ b/docs/0.10.1/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/python_with_zeppelin.html
+++ b/docs/0.10.1/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/r_with_zeppelin.html
+++ b/docs/0.10.1/quickstart/r_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/spark_with_zeppelin.html
+++ b/docs/0.10.1/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/sql_with_zeppelin.html
+++ b/docs/0.10.1/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/tutorial.html
+++ b/docs/0.10.1/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/quickstart/yarn.html
+++ b/docs/0.10.1/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/screenshots.html
+++ b/docs/0.10.1/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/search.html
+++ b/docs/0.10.1/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/basics/hadoop_integration.html
+++ b/docs/0.10.1/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/basics/how_to_build.html
+++ b/docs/0.10.1/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/basics/multi_user_support.html
+++ b/docs/0.10.1/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/basics/systemd.html
+++ b/docs/0.10.1/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/cdh.html
+++ b/docs/0.10.1/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/docker.html
+++ b/docs/0.10.1/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.10.1/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.10.1/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/virtual_machine.html
+++ b/docs/0.10.1/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/deployment/yarn_install.html
+++ b/docs/0.10.1/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/operation/configuration.html
+++ b/docs/0.10.1/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/operation/monitoring.html
+++ b/docs/0.10.1/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/operation/proxy_setting.html
+++ b/docs/0.10.1/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/operation/trouble_shooting.html
+++ b/docs/0.10.1/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/operation/upgrading.html
+++ b/docs/0.10.1/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/security/authentication_nginx.html
+++ b/docs/0.10.1/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/security/datasource_authorization.html
+++ b/docs/0.10.1/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/security/http_security_headers.html
+++ b/docs/0.10.1/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/security/notebook_authorization.html
+++ b/docs/0.10.1/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/security/shiro_authentication.html
+++ b/docs/0.10.1/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/setup/storage/storage.html
+++ b/docs/0.10.1/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/display_system/angular_backend.html
+++ b/docs/0.10.1/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/display_system/angular_frontend.html
+++ b/docs/0.10.1/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/display_system/basic.html
+++ b/docs/0.10.1/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/dynamic_form/intro.html
+++ b/docs/0.10.1/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/dependency_management.html
+++ b/docs/0.10.1/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/dynamic_loading.html
+++ b/docs/0.10.1/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/execution_hooks.html
+++ b/docs/0.10.1/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/installation.html
+++ b/docs/0.10.1/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.10.1/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/overview.html
+++ b/docs/0.10.1/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/interpreter/user_impersonation.html
+++ b/docs/0.10.1/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/cron_scheduler.html
+++ b/docs/0.10.1/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/customizing_homepage.html
+++ b/docs/0.10.1/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/notebook_actions.html
+++ b/docs/0.10.1/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/personalized_mode.html
+++ b/docs/0.10.1/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.10.1/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/other_features/zeppelin_context.html
+++ b/docs/0.10.1/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/configuration.html
+++ b/docs/0.10.1/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/credential.html
+++ b/docs/0.10.1/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/helium.html
+++ b/docs/0.10.1/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/interpreter.html
+++ b/docs/0.10.1/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/notebook.html
+++ b/docs/0.10.1/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/notebook_repository.html
+++ b/docs/0.10.1/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/rest_api/zeppelin_server.html
+++ b/docs/0.10.1/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.10.1/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.10.1/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.10.1/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.10.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/contribution/how_to_contribute_code.html
+++ b/docs/0.11.0/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/contribution/how_to_contribute_website.html
+++ b/docs/0.11.0/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/contribution/useful_developer_tools.html
+++ b/docs/0.11.0/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/helium/overview.html
+++ b/docs/0.11.0/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/helium/writing_application.html
+++ b/docs/0.11.0/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/helium/writing_spell.html
+++ b/docs/0.11.0/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/helium/writing_visualization_basic.html
+++ b/docs/0.11.0/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/helium/writing_visualization_transformation.html
+++ b/docs/0.11.0/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/development/writing_zeppelin_interpreter.html
+++ b/docs/0.11.0/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/index.html
+++ b/docs/0.11.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/alluxio.html
+++ b/docs/0.11.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/bigquery.html
+++ b/docs/0.11.0/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/cassandra.html
+++ b/docs/0.11.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/elasticsearch.html
+++ b/docs/0.11.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/flink.html
+++ b/docs/0.11.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/groovy.html
+++ b/docs/0.11.0/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/hbase.html
+++ b/docs/0.11.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/hdfs.html
+++ b/docs/0.11.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/hive.html
+++ b/docs/0.11.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/influxdb.html
+++ b/docs/0.11.0/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/java.html
+++ b/docs/0.11.0/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/jdbc.html
+++ b/docs/0.11.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/jupyter.html
+++ b/docs/0.11.0/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/livy.html
+++ b/docs/0.11.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/mahout.html
+++ b/docs/0.11.0/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/markdown.html
+++ b/docs/0.11.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/mongodb.html
+++ b/docs/0.11.0/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/neo4j.html
+++ b/docs/0.11.0/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/postgresql.html
+++ b/docs/0.11.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/python.html
+++ b/docs/0.11.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/r.html
+++ b/docs/0.11.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/shell.html
+++ b/docs/0.11.0/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/spark.html
+++ b/docs/0.11.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/sparql.html
+++ b/docs/0.11.0/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/interpreter/submarine.html
+++ b/docs/0.11.0/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/pleasecontribute.html
+++ b/docs/0.11.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/docker.html
+++ b/docs/0.11.0/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/explore_ui.html
+++ b/docs/0.11.0/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/flink_with_zeppelin.html
+++ b/docs/0.11.0/quickstart/flink_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/install.html
+++ b/docs/0.11.0/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/kubernetes.html
+++ b/docs/0.11.0/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/python_with_zeppelin.html
+++ b/docs/0.11.0/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/r_with_zeppelin.html
+++ b/docs/0.11.0/quickstart/r_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/spark_with_zeppelin.html
+++ b/docs/0.11.0/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/sql_with_zeppelin.html
+++ b/docs/0.11.0/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/tutorial.html
+++ b/docs/0.11.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/quickstart/yarn.html
+++ b/docs/0.11.0/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/screenshots.html
+++ b/docs/0.11.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/search.html
+++ b/docs/0.11.0/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/basics/hadoop_integration.html
+++ b/docs/0.11.0/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/basics/how_to_build.html
+++ b/docs/0.11.0/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/basics/multi_user_support.html
+++ b/docs/0.11.0/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/basics/systemd.html
+++ b/docs/0.11.0/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/cdh.html
+++ b/docs/0.11.0/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/docker.html
+++ b/docs/0.11.0/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.11.0/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.11.0/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/virtual_machine.html
+++ b/docs/0.11.0/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/deployment/yarn_install.html
+++ b/docs/0.11.0/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/operation/configuration.html
+++ b/docs/0.11.0/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/operation/monitoring.html
+++ b/docs/0.11.0/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/operation/proxy_setting.html
+++ b/docs/0.11.0/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/operation/trouble_shooting.html
+++ b/docs/0.11.0/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/operation/upgrading.html
+++ b/docs/0.11.0/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/security/authentication_nginx.html
+++ b/docs/0.11.0/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/security/datasource_authorization.html
+++ b/docs/0.11.0/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/security/http_security_headers.html
+++ b/docs/0.11.0/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/security/notebook_authorization.html
+++ b/docs/0.11.0/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/security/shiro_authentication.html
+++ b/docs/0.11.0/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/storage/configuration_storage.html
+++ b/docs/0.11.0/setup/storage/configuration_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/setup/storage/notebook_storage.html
+++ b/docs/0.11.0/setup/storage/notebook_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/display_system/angular_backend.html
+++ b/docs/0.11.0/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/display_system/angular_frontend.html
+++ b/docs/0.11.0/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/display_system/basic.html
+++ b/docs/0.11.0/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/dynamic_form/intro.html
+++ b/docs/0.11.0/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/dependency_management.html
+++ b/docs/0.11.0/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/dynamic_loading.html
+++ b/docs/0.11.0/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/execution_hooks.html
+++ b/docs/0.11.0/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/installation.html
+++ b/docs/0.11.0/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.11.0/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/overview.html
+++ b/docs/0.11.0/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/interpreter/user_impersonation.html
+++ b/docs/0.11.0/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/cron_scheduler.html
+++ b/docs/0.11.0/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/customizing_homepage.html
+++ b/docs/0.11.0/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/notebook_actions.html
+++ b/docs/0.11.0/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/personalized_mode.html
+++ b/docs/0.11.0/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.11.0/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/other_features/zeppelin_context.html
+++ b/docs/0.11.0/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/configuration.html
+++ b/docs/0.11.0/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/credential.html
+++ b/docs/0.11.0/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/helium.html
+++ b/docs/0.11.0/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/interpreter.html
+++ b/docs/0.11.0/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/notebook.html
+++ b/docs/0.11.0/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/notebook_repository.html
+++ b/docs/0.11.0/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/rest_api/zeppelin_server.html
+++ b/docs/0.11.0/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.11.0/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.0/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.11.0/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/contribution/how_to_contribute_code.html
+++ b/docs/0.11.1/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/contribution/how_to_contribute_website.html
+++ b/docs/0.11.1/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/contribution/useful_developer_tools.html
+++ b/docs/0.11.1/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/helium/overview.html
+++ b/docs/0.11.1/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/helium/writing_application.html
+++ b/docs/0.11.1/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/helium/writing_spell.html
+++ b/docs/0.11.1/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/helium/writing_visualization_basic.html
+++ b/docs/0.11.1/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/helium/writing_visualization_transformation.html
+++ b/docs/0.11.1/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/development/writing_zeppelin_interpreter.html
+++ b/docs/0.11.1/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/index.html
+++ b/docs/0.11.1/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/alluxio.html
+++ b/docs/0.11.1/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/bigquery.html
+++ b/docs/0.11.1/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/cassandra.html
+++ b/docs/0.11.1/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/elasticsearch.html
+++ b/docs/0.11.1/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/flink.html
+++ b/docs/0.11.1/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/groovy.html
+++ b/docs/0.11.1/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/hbase.html
+++ b/docs/0.11.1/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/hdfs.html
+++ b/docs/0.11.1/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/hive.html
+++ b/docs/0.11.1/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/influxdb.html
+++ b/docs/0.11.1/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/java.html
+++ b/docs/0.11.1/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/jdbc.html
+++ b/docs/0.11.1/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/jupyter.html
+++ b/docs/0.11.1/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/livy.html
+++ b/docs/0.11.1/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/mahout.html
+++ b/docs/0.11.1/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/markdown.html
+++ b/docs/0.11.1/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/mongodb.html
+++ b/docs/0.11.1/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/neo4j.html
+++ b/docs/0.11.1/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/postgresql.html
+++ b/docs/0.11.1/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/python.html
+++ b/docs/0.11.1/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/r.html
+++ b/docs/0.11.1/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/shell.html
+++ b/docs/0.11.1/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/spark.html
+++ b/docs/0.11.1/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/sparql.html
+++ b/docs/0.11.1/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/interpreter/submarine.html
+++ b/docs/0.11.1/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/pleasecontribute.html
+++ b/docs/0.11.1/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/docker.html
+++ b/docs/0.11.1/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/explore_ui.html
+++ b/docs/0.11.1/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/flink_with_zeppelin.html
+++ b/docs/0.11.1/quickstart/flink_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/install.html
+++ b/docs/0.11.1/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/kubernetes.html
+++ b/docs/0.11.1/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/python_with_zeppelin.html
+++ b/docs/0.11.1/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/r_with_zeppelin.html
+++ b/docs/0.11.1/quickstart/r_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/spark_with_zeppelin.html
+++ b/docs/0.11.1/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/sql_with_zeppelin.html
+++ b/docs/0.11.1/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/tutorial.html
+++ b/docs/0.11.1/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/quickstart/yarn.html
+++ b/docs/0.11.1/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/screenshots.html
+++ b/docs/0.11.1/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/search.html
+++ b/docs/0.11.1/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/basics/hadoop_integration.html
+++ b/docs/0.11.1/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/basics/how_to_build.html
+++ b/docs/0.11.1/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/basics/multi_user_support.html
+++ b/docs/0.11.1/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/basics/systemd.html
+++ b/docs/0.11.1/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/cdh.html
+++ b/docs/0.11.1/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/docker.html
+++ b/docs/0.11.1/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.11.1/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.11.1/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/virtual_machine.html
+++ b/docs/0.11.1/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/deployment/yarn_install.html
+++ b/docs/0.11.1/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/operation/configuration.html
+++ b/docs/0.11.1/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/operation/monitoring.html
+++ b/docs/0.11.1/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/operation/proxy_setting.html
+++ b/docs/0.11.1/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/operation/trouble_shooting.html
+++ b/docs/0.11.1/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/operation/upgrading.html
+++ b/docs/0.11.1/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/security/authentication_nginx.html
+++ b/docs/0.11.1/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/security/datasource_authorization.html
+++ b/docs/0.11.1/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/security/http_security_headers.html
+++ b/docs/0.11.1/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/security/notebook_authorization.html
+++ b/docs/0.11.1/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/security/shiro_authentication.html
+++ b/docs/0.11.1/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/storage/configuration_storage.html
+++ b/docs/0.11.1/setup/storage/configuration_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/setup/storage/notebook_storage.html
+++ b/docs/0.11.1/setup/storage/notebook_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/display_system/angular_backend.html
+++ b/docs/0.11.1/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/display_system/angular_frontend.html
+++ b/docs/0.11.1/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/display_system/basic.html
+++ b/docs/0.11.1/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/dynamic_form/intro.html
+++ b/docs/0.11.1/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/dependency_management.html
+++ b/docs/0.11.1/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/dynamic_loading.html
+++ b/docs/0.11.1/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/execution_hooks.html
+++ b/docs/0.11.1/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/installation.html
+++ b/docs/0.11.1/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.11.1/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/overview.html
+++ b/docs/0.11.1/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/interpreter/user_impersonation.html
+++ b/docs/0.11.1/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/cron_scheduler.html
+++ b/docs/0.11.1/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/customizing_homepage.html
+++ b/docs/0.11.1/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/notebook_actions.html
+++ b/docs/0.11.1/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/personalized_mode.html
+++ b/docs/0.11.1/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.11.1/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/other_features/zeppelin_context.html
+++ b/docs/0.11.1/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/configuration.html
+++ b/docs/0.11.1/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/credential.html
+++ b/docs/0.11.1/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/helium.html
+++ b/docs/0.11.1/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/interpreter.html
+++ b/docs/0.11.1/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/notebook.html
+++ b/docs/0.11.1/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/notebook_repository.html
+++ b/docs/0.11.1/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/rest_api/zeppelin_server.html
+++ b/docs/0.11.1/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.11.1/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.1/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.11.1/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/contribution/how_to_contribute_code.html
+++ b/docs/0.11.2/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/contribution/how_to_contribute_website.html
+++ b/docs/0.11.2/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/contribution/useful_developer_tools.html
+++ b/docs/0.11.2/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/helium/overview.html
+++ b/docs/0.11.2/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/helium/writing_application.html
+++ b/docs/0.11.2/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/helium/writing_spell.html
+++ b/docs/0.11.2/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/helium/writing_visualization_basic.html
+++ b/docs/0.11.2/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/helium/writing_visualization_transformation.html
+++ b/docs/0.11.2/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/development/writing_zeppelin_interpreter.html
+++ b/docs/0.11.2/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/index.html
+++ b/docs/0.11.2/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/alluxio.html
+++ b/docs/0.11.2/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/bigquery.html
+++ b/docs/0.11.2/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/cassandra.html
+++ b/docs/0.11.2/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/elasticsearch.html
+++ b/docs/0.11.2/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/flink.html
+++ b/docs/0.11.2/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/groovy.html
+++ b/docs/0.11.2/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/hbase.html
+++ b/docs/0.11.2/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/hdfs.html
+++ b/docs/0.11.2/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/hive.html
+++ b/docs/0.11.2/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/influxdb.html
+++ b/docs/0.11.2/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/java.html
+++ b/docs/0.11.2/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/jdbc.html
+++ b/docs/0.11.2/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/jupyter.html
+++ b/docs/0.11.2/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/livy.html
+++ b/docs/0.11.2/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/mahout.html
+++ b/docs/0.11.2/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/markdown.html
+++ b/docs/0.11.2/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/mongodb.html
+++ b/docs/0.11.2/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/neo4j.html
+++ b/docs/0.11.2/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/postgresql.html
+++ b/docs/0.11.2/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/python.html
+++ b/docs/0.11.2/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/r.html
+++ b/docs/0.11.2/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/shell.html
+++ b/docs/0.11.2/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/spark.html
+++ b/docs/0.11.2/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/sparql.html
+++ b/docs/0.11.2/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/interpreter/submarine.html
+++ b/docs/0.11.2/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/pleasecontribute.html
+++ b/docs/0.11.2/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/docker.html
+++ b/docs/0.11.2/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/explore_ui.html
+++ b/docs/0.11.2/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/flink_with_zeppelin.html
+++ b/docs/0.11.2/quickstart/flink_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/install.html
+++ b/docs/0.11.2/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/kubernetes.html
+++ b/docs/0.11.2/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/python_with_zeppelin.html
+++ b/docs/0.11.2/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/r_with_zeppelin.html
+++ b/docs/0.11.2/quickstart/r_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/spark_with_zeppelin.html
+++ b/docs/0.11.2/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/sql_with_zeppelin.html
+++ b/docs/0.11.2/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/tutorial.html
+++ b/docs/0.11.2/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/quickstart/yarn.html
+++ b/docs/0.11.2/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/screenshots.html
+++ b/docs/0.11.2/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/search.html
+++ b/docs/0.11.2/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/basics/hadoop_integration.html
+++ b/docs/0.11.2/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/basics/how_to_build.html
+++ b/docs/0.11.2/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/basics/multi_user_support.html
+++ b/docs/0.11.2/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/basics/systemd.html
+++ b/docs/0.11.2/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/cdh.html
+++ b/docs/0.11.2/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/docker.html
+++ b/docs/0.11.2/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.11.2/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.11.2/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/virtual_machine.html
+++ b/docs/0.11.2/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/deployment/yarn_install.html
+++ b/docs/0.11.2/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/operation/configuration.html
+++ b/docs/0.11.2/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/operation/monitoring.html
+++ b/docs/0.11.2/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/operation/proxy_setting.html
+++ b/docs/0.11.2/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/operation/trouble_shooting.html
+++ b/docs/0.11.2/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/operation/upgrading.html
+++ b/docs/0.11.2/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/security/authentication_nginx.html
+++ b/docs/0.11.2/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/security/datasource_authorization.html
+++ b/docs/0.11.2/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/security/http_security_headers.html
+++ b/docs/0.11.2/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/security/notebook_authorization.html
+++ b/docs/0.11.2/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/security/shiro_authentication.html
+++ b/docs/0.11.2/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/storage/configuration_storage.html
+++ b/docs/0.11.2/setup/storage/configuration_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/setup/storage/notebook_storage.html
+++ b/docs/0.11.2/setup/storage/notebook_storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/display_system/angular_backend.html
+++ b/docs/0.11.2/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/display_system/angular_frontend.html
+++ b/docs/0.11.2/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/display_system/basic.html
+++ b/docs/0.11.2/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/dynamic_form/intro.html
+++ b/docs/0.11.2/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/dependency_management.html
+++ b/docs/0.11.2/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/dynamic_loading.html
+++ b/docs/0.11.2/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/execution_hooks.html
+++ b/docs/0.11.2/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/installation.html
+++ b/docs/0.11.2/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.11.2/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/overview.html
+++ b/docs/0.11.2/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/interpreter/user_impersonation.html
+++ b/docs/0.11.2/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/cron_scheduler.html
+++ b/docs/0.11.2/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/customizing_homepage.html
+++ b/docs/0.11.2/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/notebook_actions.html
+++ b/docs/0.11.2/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/personalized_mode.html
+++ b/docs/0.11.2/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.11.2/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/other_features/zeppelin_context.html
+++ b/docs/0.11.2/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/configuration.html
+++ b/docs/0.11.2/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/credential.html
+++ b/docs/0.11.2/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/helium.html
+++ b/docs/0.11.2/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/interpreter.html
+++ b/docs/0.11.2/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/notebook.html
+++ b/docs/0.11.2/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/notebook_repository.html
+++ b/docs/0.11.2/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/rest_api/zeppelin_server.html
+++ b/docs/0.11.2/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.11.2/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.11.2/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.11.2/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.11.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/contribution/how_to_contribute_code.html
+++ b/docs/0.12.0/development/contribution/how_to_contribute_code.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/contribution/how_to_contribute_website.html
+++ b/docs/0.12.0/development/contribution/how_to_contribute_website.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/contribution/useful_developer_tools.html
+++ b/docs/0.12.0/development/contribution/useful_developer_tools.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/helium/overview.html
+++ b/docs/0.12.0/development/helium/overview.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/helium/writing_application.html
+++ b/docs/0.12.0/development/helium/writing_application.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/helium/writing_spell.html
+++ b/docs/0.12.0/development/helium/writing_spell.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/helium/writing_visualization_basic.html
+++ b/docs/0.12.0/development/helium/writing_visualization_basic.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/helium/writing_visualization_transformation.html
+++ b/docs/0.12.0/development/helium/writing_visualization_transformation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/development/writing_zeppelin_interpreter.html
+++ b/docs/0.12.0/development/writing_zeppelin_interpreter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/index.html
+++ b/docs/0.12.0/index.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/alluxio.html
+++ b/docs/0.12.0/interpreter/alluxio.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/bigquery.html
+++ b/docs/0.12.0/interpreter/bigquery.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/cassandra.html
+++ b/docs/0.12.0/interpreter/cassandra.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/elasticsearch.html
+++ b/docs/0.12.0/interpreter/elasticsearch.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/flink.html
+++ b/docs/0.12.0/interpreter/flink.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/groovy.html
+++ b/docs/0.12.0/interpreter/groovy.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/hbase.html
+++ b/docs/0.12.0/interpreter/hbase.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/hdfs.html
+++ b/docs/0.12.0/interpreter/hdfs.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/hive.html
+++ b/docs/0.12.0/interpreter/hive.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/influxdb.html
+++ b/docs/0.12.0/interpreter/influxdb.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/java.html
+++ b/docs/0.12.0/interpreter/java.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/jdbc.html
+++ b/docs/0.12.0/interpreter/jdbc.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/jupyter.html
+++ b/docs/0.12.0/interpreter/jupyter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/livy.html
+++ b/docs/0.12.0/interpreter/livy.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/mahout.html
+++ b/docs/0.12.0/interpreter/mahout.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/markdown.html
+++ b/docs/0.12.0/interpreter/markdown.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/mongodb.html
+++ b/docs/0.12.0/interpreter/mongodb.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/neo4j.html
+++ b/docs/0.12.0/interpreter/neo4j.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/postgresql.html
+++ b/docs/0.12.0/interpreter/postgresql.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/python.html
+++ b/docs/0.12.0/interpreter/python.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/r.html
+++ b/docs/0.12.0/interpreter/r.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/shell.html
+++ b/docs/0.12.0/interpreter/shell.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/spark.html
+++ b/docs/0.12.0/interpreter/spark.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/interpreter/sparql.html
+++ b/docs/0.12.0/interpreter/sparql.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/pleasecontribute.html
+++ b/docs/0.12.0/pleasecontribute.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/docker.html
+++ b/docs/0.12.0/quickstart/docker.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/explore_ui.html
+++ b/docs/0.12.0/quickstart/explore_ui.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/flink_with_zeppelin.html
+++ b/docs/0.12.0/quickstart/flink_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/install.html
+++ b/docs/0.12.0/quickstart/install.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/kubernetes.html
+++ b/docs/0.12.0/quickstart/kubernetes.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/python_with_zeppelin.html
+++ b/docs/0.12.0/quickstart/python_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/r_with_zeppelin.html
+++ b/docs/0.12.0/quickstart/r_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/spark_with_zeppelin.html
+++ b/docs/0.12.0/quickstart/spark_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/sql_with_zeppelin.html
+++ b/docs/0.12.0/quickstart/sql_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/tutorial.html
+++ b/docs/0.12.0/quickstart/tutorial.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/quickstart/yarn.html
+++ b/docs/0.12.0/quickstart/yarn.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/screenshots.html
+++ b/docs/0.12.0/screenshots.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/search.html
+++ b/docs/0.12.0/search.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/basics/hadoop_integration.html
+++ b/docs/0.12.0/setup/basics/hadoop_integration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/basics/how_to_build.html
+++ b/docs/0.12.0/setup/basics/how_to_build.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/basics/multi_user_support.html
+++ b/docs/0.12.0/setup/basics/multi_user_support.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/basics/systemd.html
+++ b/docs/0.12.0/setup/basics/systemd.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/cdh.html
+++ b/docs/0.12.0/setup/deployment/cdh.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/docker.html
+++ b/docs/0.12.0/setup/deployment/docker.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.12.0/setup/deployment/flink_and_spark_cluster.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.12.0/setup/deployment/spark_cluster_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/virtual_machine.html
+++ b/docs/0.12.0/setup/deployment/virtual_machine.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/deployment/yarn_install.html
+++ b/docs/0.12.0/setup/deployment/yarn_install.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/operation/configuration.html
+++ b/docs/0.12.0/setup/operation/configuration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/operation/monitoring.html
+++ b/docs/0.12.0/setup/operation/monitoring.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/operation/proxy_setting.html
+++ b/docs/0.12.0/setup/operation/proxy_setting.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/operation/trouble_shooting.html
+++ b/docs/0.12.0/setup/operation/trouble_shooting.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/operation/upgrading.html
+++ b/docs/0.12.0/setup/operation/upgrading.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/security/authentication_nginx.html
+++ b/docs/0.12.0/setup/security/authentication_nginx.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/security/datasource_authorization.html
+++ b/docs/0.12.0/setup/security/datasource_authorization.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/security/http_security_headers.html
+++ b/docs/0.12.0/setup/security/http_security_headers.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/security/notebook_authorization.html
+++ b/docs/0.12.0/setup/security/notebook_authorization.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/security/shiro_authentication.html
+++ b/docs/0.12.0/setup/security/shiro_authentication.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/storage/configuration_storage.html
+++ b/docs/0.12.0/setup/storage/configuration_storage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/setup/storage/notebook_storage.html
+++ b/docs/0.12.0/setup/storage/notebook_storage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/display_system/angular_backend.html
+++ b/docs/0.12.0/usage/display_system/angular_backend.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/display_system/angular_frontend.html
+++ b/docs/0.12.0/usage/display_system/angular_frontend.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/display_system/basic.html
+++ b/docs/0.12.0/usage/display_system/basic.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/dynamic_form/intro.html
+++ b/docs/0.12.0/usage/dynamic_form/intro.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/dependency_management.html
+++ b/docs/0.12.0/usage/interpreter/dependency_management.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/dynamic_loading.html
+++ b/docs/0.12.0/usage/interpreter/dynamic_loading.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/execution_hooks.html
+++ b/docs/0.12.0/usage/interpreter/execution_hooks.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/installation.html
+++ b/docs/0.12.0/usage/interpreter/installation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.12.0/usage/interpreter/interpreter_binding_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/overview.html
+++ b/docs/0.12.0/usage/interpreter/overview.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/interpreter/user_impersonation.html
+++ b/docs/0.12.0/usage/interpreter/user_impersonation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/cron_scheduler.html
+++ b/docs/0.12.0/usage/other_features/cron_scheduler.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/customizing_homepage.html
+++ b/docs/0.12.0/usage/other_features/customizing_homepage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/notebook_actions.html
+++ b/docs/0.12.0/usage/other_features/notebook_actions.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/personalized_mode.html
+++ b/docs/0.12.0/usage/other_features/personalized_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.12.0/usage/other_features/publishing_paragraphs.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/other_features/zeppelin_context.html
+++ b/docs/0.12.0/usage/other_features/zeppelin_context.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/configuration.html
+++ b/docs/0.12.0/usage/rest_api/configuration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/credential.html
+++ b/docs/0.12.0/usage/rest_api/credential.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/helium.html
+++ b/docs/0.12.0/usage/rest_api/helium.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/interpreter.html
+++ b/docs/0.12.0/usage/rest_api/interpreter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/notebook.html
+++ b/docs/0.12.0/usage/rest_api/notebook.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/notebook_repository.html
+++ b/docs/0.12.0/usage/rest_api/notebook_repository.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/rest_api/zeppelin_server.html
+++ b/docs/0.12.0/usage/rest_api/zeppelin_server.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.12.0/usage/zeppelin_sdk/client_api.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.0/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.12.0/usage/zeppelin_sdk/session_api.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/contribution/how_to_contribute_code.html
+++ b/docs/0.12.1/development/contribution/how_to_contribute_code.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/contribution/how_to_contribute_website.html
+++ b/docs/0.12.1/development/contribution/how_to_contribute_website.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/contribution/useful_developer_tools.html
+++ b/docs/0.12.1/development/contribution/useful_developer_tools.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/helium/overview.html
+++ b/docs/0.12.1/development/helium/overview.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/helium/writing_application.html
+++ b/docs/0.12.1/development/helium/writing_application.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/helium/writing_spell.html
+++ b/docs/0.12.1/development/helium/writing_spell.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/helium/writing_visualization_basic.html
+++ b/docs/0.12.1/development/helium/writing_visualization_basic.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/helium/writing_visualization_transformation.html
+++ b/docs/0.12.1/development/helium/writing_visualization_transformation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/development/writing_zeppelin_interpreter.html
+++ b/docs/0.12.1/development/writing_zeppelin_interpreter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/index.html
+++ b/docs/0.12.1/index.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/alluxio.html
+++ b/docs/0.12.1/interpreter/alluxio.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/bigquery.html
+++ b/docs/0.12.1/interpreter/bigquery.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/cassandra.html
+++ b/docs/0.12.1/interpreter/cassandra.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/elasticsearch.html
+++ b/docs/0.12.1/interpreter/elasticsearch.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/flink.html
+++ b/docs/0.12.1/interpreter/flink.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/groovy.html
+++ b/docs/0.12.1/interpreter/groovy.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/hbase.html
+++ b/docs/0.12.1/interpreter/hbase.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/hdfs.html
+++ b/docs/0.12.1/interpreter/hdfs.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/hive.html
+++ b/docs/0.12.1/interpreter/hive.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/influxdb.html
+++ b/docs/0.12.1/interpreter/influxdb.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/java.html
+++ b/docs/0.12.1/interpreter/java.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/jdbc.html
+++ b/docs/0.12.1/interpreter/jdbc.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/jupyter.html
+++ b/docs/0.12.1/interpreter/jupyter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/livy.html
+++ b/docs/0.12.1/interpreter/livy.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/mahout.html
+++ b/docs/0.12.1/interpreter/mahout.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/markdown.html
+++ b/docs/0.12.1/interpreter/markdown.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/mongodb.html
+++ b/docs/0.12.1/interpreter/mongodb.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/neo4j.html
+++ b/docs/0.12.1/interpreter/neo4j.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/postgresql.html
+++ b/docs/0.12.1/interpreter/postgresql.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/python.html
+++ b/docs/0.12.1/interpreter/python.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/r.html
+++ b/docs/0.12.1/interpreter/r.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/shell.html
+++ b/docs/0.12.1/interpreter/shell.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/spark.html
+++ b/docs/0.12.1/interpreter/spark.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/interpreter/sparql.html
+++ b/docs/0.12.1/interpreter/sparql.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/pleasecontribute.html
+++ b/docs/0.12.1/pleasecontribute.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/docker.html
+++ b/docs/0.12.1/quickstart/docker.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/explore_ui.html
+++ b/docs/0.12.1/quickstart/explore_ui.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/flink_with_zeppelin.html
+++ b/docs/0.12.1/quickstart/flink_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/install.html
+++ b/docs/0.12.1/quickstart/install.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/kubernetes.html
+++ b/docs/0.12.1/quickstart/kubernetes.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/python_with_zeppelin.html
+++ b/docs/0.12.1/quickstart/python_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/r_with_zeppelin.html
+++ b/docs/0.12.1/quickstart/r_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/spark_with_zeppelin.html
+++ b/docs/0.12.1/quickstart/spark_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/sql_with_zeppelin.html
+++ b/docs/0.12.1/quickstart/sql_with_zeppelin.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/tutorial.html
+++ b/docs/0.12.1/quickstart/tutorial.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/quickstart/yarn.html
+++ b/docs/0.12.1/quickstart/yarn.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/screenshots.html
+++ b/docs/0.12.1/screenshots.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/search.html
+++ b/docs/0.12.1/search.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/basics/hadoop_integration.html
+++ b/docs/0.12.1/setup/basics/hadoop_integration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/basics/how_to_build.html
+++ b/docs/0.12.1/setup/basics/how_to_build.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/basics/multi_user_support.html
+++ b/docs/0.12.1/setup/basics/multi_user_support.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/basics/systemd.html
+++ b/docs/0.12.1/setup/basics/systemd.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/cdh.html
+++ b/docs/0.12.1/setup/deployment/cdh.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/docker.html
+++ b/docs/0.12.1/setup/deployment/docker.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.12.1/setup/deployment/flink_and_spark_cluster.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.12.1/setup/deployment/spark_cluster_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/virtual_machine.html
+++ b/docs/0.12.1/setup/deployment/virtual_machine.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/deployment/yarn_install.html
+++ b/docs/0.12.1/setup/deployment/yarn_install.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/operation/configuration.html
+++ b/docs/0.12.1/setup/operation/configuration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/operation/monitoring.html
+++ b/docs/0.12.1/setup/operation/monitoring.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/operation/proxy_setting.html
+++ b/docs/0.12.1/setup/operation/proxy_setting.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/operation/trouble_shooting.html
+++ b/docs/0.12.1/setup/operation/trouble_shooting.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/operation/upgrading.html
+++ b/docs/0.12.1/setup/operation/upgrading.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/security/authentication_nginx.html
+++ b/docs/0.12.1/setup/security/authentication_nginx.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/security/datasource_authorization.html
+++ b/docs/0.12.1/setup/security/datasource_authorization.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/security/http_security_headers.html
+++ b/docs/0.12.1/setup/security/http_security_headers.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/security/notebook_authorization.html
+++ b/docs/0.12.1/setup/security/notebook_authorization.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/security/shiro_authentication.html
+++ b/docs/0.12.1/setup/security/shiro_authentication.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/storage/configuration_storage.html
+++ b/docs/0.12.1/setup/storage/configuration_storage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/setup/storage/notebook_storage.html
+++ b/docs/0.12.1/setup/storage/notebook_storage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/display_system/angular_backend.html
+++ b/docs/0.12.1/usage/display_system/angular_backend.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/display_system/angular_frontend.html
+++ b/docs/0.12.1/usage/display_system/angular_frontend.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/display_system/basic.html
+++ b/docs/0.12.1/usage/display_system/basic.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/dynamic_form/intro.html
+++ b/docs/0.12.1/usage/dynamic_form/intro.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/dependency_management.html
+++ b/docs/0.12.1/usage/interpreter/dependency_management.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/dynamic_loading.html
+++ b/docs/0.12.1/usage/interpreter/dynamic_loading.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/execution_hooks.html
+++ b/docs/0.12.1/usage/interpreter/execution_hooks.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/installation.html
+++ b/docs/0.12.1/usage/interpreter/installation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.12.1/usage/interpreter/interpreter_binding_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/overview.html
+++ b/docs/0.12.1/usage/interpreter/overview.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/interpreter/user_impersonation.html
+++ b/docs/0.12.1/usage/interpreter/user_impersonation.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/cron_scheduler.html
+++ b/docs/0.12.1/usage/other_features/cron_scheduler.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/customizing_homepage.html
+++ b/docs/0.12.1/usage/other_features/customizing_homepage.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/notebook_actions.html
+++ b/docs/0.12.1/usage/other_features/notebook_actions.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/personalized_mode.html
+++ b/docs/0.12.1/usage/other_features/personalized_mode.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.12.1/usage/other_features/publishing_paragraphs.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/other_features/zeppelin_context.html
+++ b/docs/0.12.1/usage/other_features/zeppelin_context.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/configuration.html
+++ b/docs/0.12.1/usage/rest_api/configuration.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/credential.html
+++ b/docs/0.12.1/usage/rest_api/credential.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/helium.html
+++ b/docs/0.12.1/usage/rest_api/helium.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/interpreter.html
+++ b/docs/0.12.1/usage/rest_api/interpreter.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/notebook.html
+++ b/docs/0.12.1/usage/rest_api/notebook.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/notebook_repository.html
+++ b/docs/0.12.1/usage/rest_api/notebook_repository.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/rest_api/zeppelin_server.html
+++ b/docs/0.12.1/usage/rest_api/zeppelin_server.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.12.1/usage/zeppelin_sdk/client_api.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.12.1/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.12.1/usage/zeppelin_sdk/session_api.html
@@ -11,10 +11,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.12.1/assets/themes/zeppelin/font-awesome-4.2.0/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.5.0-incubating/development/howtocontribute.html
+++ b/docs/0.5.0-incubating/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/development/howtocontributewebsite.html
+++ b/docs/0.5.0-incubating/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/development/writingzeppelininterpreter.html
+++ b/docs/0.5.0-incubating/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/displaysystem/angular.html
+++ b/docs/0.5.0-incubating/displaysystem/angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/displaysystem/display.html
+++ b/docs/0.5.0-incubating/displaysystem/display.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/displaysystem/table.html
+++ b/docs/0.5.0-incubating/displaysystem/table.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/docs.html
+++ b/docs/0.5.0-incubating/docs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/index.html
+++ b/docs/0.5.0-incubating/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/install/install.html
+++ b/docs/0.5.0-incubating/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/install/yarn_install.html
+++ b/docs/0.5.0-incubating/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/cassandra.html
+++ b/docs/0.5.0-incubating/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/flink.html
+++ b/docs/0.5.0-incubating/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/geode.html
+++ b/docs/0.5.0-incubating/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/ignite.html
+++ b/docs/0.5.0-incubating/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/lens.html
+++ b/docs/0.5.0-incubating/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/postgresql.html
+++ b/docs/0.5.0-incubating/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/interpreter/spark.html
+++ b/docs/0.5.0-incubating/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/manual/dynamicform.html
+++ b/docs/0.5.0-incubating/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/manual/interpreters.html
+++ b/docs/0.5.0-incubating/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/manual/notebookashomepage.html
+++ b/docs/0.5.0-incubating/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/pleasecontribute.html
+++ b/docs/0.5.0-incubating/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/rest-api/rest-interpreter.html
+++ b/docs/0.5.0-incubating/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/rest-api/rest-notebook.html
+++ b/docs/0.5.0-incubating/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/screenshots.html
+++ b/docs/0.5.0-incubating/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/storage/storage.html
+++ b/docs/0.5.0-incubating/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.0-incubating/tutorial/tutorial.html
+++ b/docs/0.5.0-incubating/tutorial/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.0-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/development/howtocontribute.html
+++ b/docs/0.5.5-incubating/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/development/howtocontributewebsite.html
+++ b/docs/0.5.5-incubating/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/development/writingzeppelininterpreter.html
+++ b/docs/0.5.5-incubating/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/displaysystem/angular.html
+++ b/docs/0.5.5-incubating/displaysystem/angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/displaysystem/display.html
+++ b/docs/0.5.5-incubating/displaysystem/display.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/displaysystem/table.html
+++ b/docs/0.5.5-incubating/displaysystem/table.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/docs.html
+++ b/docs/0.5.5-incubating/docs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/index.html
+++ b/docs/0.5.5-incubating/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/install/install.html
+++ b/docs/0.5.5-incubating/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/install/yarn_install.html
+++ b/docs/0.5.5-incubating/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/cassandra.html
+++ b/docs/0.5.5-incubating/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/flink.html
+++ b/docs/0.5.5-incubating/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/geode.html
+++ b/docs/0.5.5-incubating/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/ignite.html
+++ b/docs/0.5.5-incubating/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/lens.html
+++ b/docs/0.5.5-incubating/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/postgresql.html
+++ b/docs/0.5.5-incubating/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/interpreter/spark.html
+++ b/docs/0.5.5-incubating/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/manual/dynamicform.html
+++ b/docs/0.5.5-incubating/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/manual/interpreters.html
+++ b/docs/0.5.5-incubating/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/manual/notebookashomepage.html
+++ b/docs/0.5.5-incubating/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/pleasecontribute.html
+++ b/docs/0.5.5-incubating/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/rest-api/rest-interpreter.html
+++ b/docs/0.5.5-incubating/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/rest-api/rest-notebook.html
+++ b/docs/0.5.5-incubating/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/screenshots.html
+++ b/docs/0.5.5-incubating/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/storage/storage.html
+++ b/docs/0.5.5-incubating/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.5-incubating/tutorial/tutorial.html
+++ b/docs/0.5.5-incubating/tutorial/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.5-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/development/howtocontribute.html
+++ b/docs/0.5.6-incubating/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/development/howtocontributewebsite.html
+++ b/docs/0.5.6-incubating/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/development/writingzeppelininterpreter.html
+++ b/docs/0.5.6-incubating/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/displaysystem/angular.html
+++ b/docs/0.5.6-incubating/displaysystem/angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/displaysystem/display.html
+++ b/docs/0.5.6-incubating/displaysystem/display.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/displaysystem/table.html
+++ b/docs/0.5.6-incubating/displaysystem/table.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/index.html
+++ b/docs/0.5.6-incubating/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/install/install.html
+++ b/docs/0.5.6-incubating/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/install/virtual_machine.html
+++ b/docs/0.5.6-incubating/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/install/yarn_install.html
+++ b/docs/0.5.6-incubating/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/cassandra.html
+++ b/docs/0.5.6-incubating/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/elasticsearch.html
+++ b/docs/0.5.6-incubating/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/flink.html
+++ b/docs/0.5.6-incubating/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/geode.html
+++ b/docs/0.5.6-incubating/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/hive.html
+++ b/docs/0.5.6-incubating/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/ignite.html
+++ b/docs/0.5.6-incubating/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/lens.html
+++ b/docs/0.5.6-incubating/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/markdown.html
+++ b/docs/0.5.6-incubating/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/postgresql.html
+++ b/docs/0.5.6-incubating/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/scalding.html
+++ b/docs/0.5.6-incubating/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/interpreter/spark.html
+++ b/docs/0.5.6-incubating/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/manual/dynamicform.html
+++ b/docs/0.5.6-incubating/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/manual/interpreters.html
+++ b/docs/0.5.6-incubating/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/manual/notebookashomepage.html
+++ b/docs/0.5.6-incubating/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/pleasecontribute.html
+++ b/docs/0.5.6-incubating/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/rest-api/rest-interpreter.html
+++ b/docs/0.5.6-incubating/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/rest-api/rest-notebook.html
+++ b/docs/0.5.6-incubating/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/screenshots.html
+++ b/docs/0.5.6-incubating/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/storage/storage.html
+++ b/docs/0.5.6-incubating/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.5.6-incubating/tutorial/tutorial.html
+++ b/docs/0.5.6-incubating/tutorial/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <!-- Le styles -->
     <link href="/docs/0.5.6-incubating/assets/themes/zeppelin/bootstrap/css/bootstrap.css" rel="stylesheet">

--- a/docs/0.6.0/development/howtocontribute.html
+++ b/docs/0.6.0/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/development/howtocontributewebsite.html
+++ b/docs/0.6.0/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/development/writingzeppelininterpreter.html
+++ b/docs/0.6.0/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/displaysystem/back-end-angular.html
+++ b/docs/0.6.0/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/displaysystem/basicdisplaysystem.html
+++ b/docs/0.6.0/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/displaysystem/front-end-angular.html
+++ b/docs/0.6.0/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/index.html
+++ b/docs/0.6.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/install/install.html
+++ b/docs/0.6.0/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/install/upgrade.html
+++ b/docs/0.6.0/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/install/virtual_machine.html
+++ b/docs/0.6.0/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/install/yarn_install.html
+++ b/docs/0.6.0/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/alluxio.html
+++ b/docs/0.6.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/cassandra.html
+++ b/docs/0.6.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/elasticsearch.html
+++ b/docs/0.6.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/flink.html
+++ b/docs/0.6.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/geode.html
+++ b/docs/0.6.0/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/hbase.html
+++ b/docs/0.6.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/hdfs.html
+++ b/docs/0.6.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/hive.html
+++ b/docs/0.6.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/ignite.html
+++ b/docs/0.6.0/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/jdbc.html
+++ b/docs/0.6.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/lens.html
+++ b/docs/0.6.0/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/livy.html
+++ b/docs/0.6.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/markdown.html
+++ b/docs/0.6.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/postgresql.html
+++ b/docs/0.6.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/python.html
+++ b/docs/0.6.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/r.html
+++ b/docs/0.6.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/scalding.html
+++ b/docs/0.6.0/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/interpreter/spark.html
+++ b/docs/0.6.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/dependencymanagement.html
+++ b/docs/0.6.0/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/dynamicform.html
+++ b/docs/0.6.0/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/dynamicinterpreterload.html
+++ b/docs/0.6.0/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/interpreterinstallation.html
+++ b/docs/0.6.0/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/interpreters.html
+++ b/docs/0.6.0/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/notebookashomepage.html
+++ b/docs/0.6.0/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/manual/publish.html
+++ b/docs/0.6.0/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/pleasecontribute.html
+++ b/docs/0.6.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/quickstart/explorezeppelinui.html
+++ b/docs/0.6.0/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/quickstart/tutorial.html
+++ b/docs/0.6.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/rest-api/rest-configuration.html
+++ b/docs/0.6.0/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/rest-api/rest-interpreter.html
+++ b/docs/0.6.0/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/rest-api/rest-notebook.html
+++ b/docs/0.6.0/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/screenshots.html
+++ b/docs/0.6.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/security/authentication.html
+++ b/docs/0.6.0/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/security/interpreter_authorization.html
+++ b/docs/0.6.0/security/interpreter_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/security/notebook_authorization.html
+++ b/docs/0.6.0/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/security/shiroauthentication.html
+++ b/docs/0.6.0/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.0/storage/storage.html
+++ b/docs/0.6.0/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/development/howtocontribute.html
+++ b/docs/0.6.1/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/development/howtocontributewebsite.html
+++ b/docs/0.6.1/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/development/writingzeppelininterpreter.html
+++ b/docs/0.6.1/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/displaysystem/back-end-angular.html
+++ b/docs/0.6.1/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/displaysystem/basicdisplaysystem.html
+++ b/docs/0.6.1/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/displaysystem/front-end-angular.html
+++ b/docs/0.6.1/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/index.html
+++ b/docs/0.6.1/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/install/install.html
+++ b/docs/0.6.1/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/install/upgrade.html
+++ b/docs/0.6.1/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/install/virtual_machine.html
+++ b/docs/0.6.1/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/install/yarn_install.html
+++ b/docs/0.6.1/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/alluxio.html
+++ b/docs/0.6.1/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/bigquery.html
+++ b/docs/0.6.1/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/cassandra.html
+++ b/docs/0.6.1/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/elasticsearch.html
+++ b/docs/0.6.1/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/flink.html
+++ b/docs/0.6.1/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/geode.html
+++ b/docs/0.6.1/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/hbase.html
+++ b/docs/0.6.1/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/hdfs.html
+++ b/docs/0.6.1/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/hive.html
+++ b/docs/0.6.1/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/ignite.html
+++ b/docs/0.6.1/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/jdbc.html
+++ b/docs/0.6.1/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/lens.html
+++ b/docs/0.6.1/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/livy.html
+++ b/docs/0.6.1/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/markdown.html
+++ b/docs/0.6.1/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/postgresql.html
+++ b/docs/0.6.1/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/python.html
+++ b/docs/0.6.1/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/r.html
+++ b/docs/0.6.1/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/scalding.html
+++ b/docs/0.6.1/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/interpreter/spark.html
+++ b/docs/0.6.1/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/dependencymanagement.html
+++ b/docs/0.6.1/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/dynamicform.html
+++ b/docs/0.6.1/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/dynamicinterpreterload.html
+++ b/docs/0.6.1/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/interpreterinstallation.html
+++ b/docs/0.6.1/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/interpreters.html
+++ b/docs/0.6.1/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/notebookashomepage.html
+++ b/docs/0.6.1/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/manual/publish.html
+++ b/docs/0.6.1/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/pleasecontribute.html
+++ b/docs/0.6.1/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/quickstart/explorezeppelinui.html
+++ b/docs/0.6.1/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/quickstart/tutorial.html
+++ b/docs/0.6.1/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/rest-api/rest-configuration.html
+++ b/docs/0.6.1/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/rest-api/rest-interpreter.html
+++ b/docs/0.6.1/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/rest-api/rest-notebook.html
+++ b/docs/0.6.1/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/screenshots.html
+++ b/docs/0.6.1/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/security/authentication.html
+++ b/docs/0.6.1/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/security/interpreter_authorization.html
+++ b/docs/0.6.1/security/interpreter_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/security/notebook_authorization.html
+++ b/docs/0.6.1/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/security/shiroauthentication.html
+++ b/docs/0.6.1/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.1/storage/storage.html
+++ b/docs/0.6.1/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/development/howtocontribute.html
+++ b/docs/0.6.2/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/development/howtocontributewebsite.html
+++ b/docs/0.6.2/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/development/writingzeppelininterpreter.html
+++ b/docs/0.6.2/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/displaysystem/back-end-angular.html
+++ b/docs/0.6.2/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/displaysystem/basicdisplaysystem.html
+++ b/docs/0.6.2/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/displaysystem/front-end-angular.html
+++ b/docs/0.6.2/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/index.html
+++ b/docs/0.6.2/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/install/install.html
+++ b/docs/0.6.2/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/install/upgrade.html
+++ b/docs/0.6.2/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/install/virtual_machine.html
+++ b/docs/0.6.2/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/install/yarn_install.html
+++ b/docs/0.6.2/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/alluxio.html
+++ b/docs/0.6.2/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/bigquery.html
+++ b/docs/0.6.2/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/cassandra.html
+++ b/docs/0.6.2/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/elasticsearch.html
+++ b/docs/0.6.2/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/flink.html
+++ b/docs/0.6.2/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/geode.html
+++ b/docs/0.6.2/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/hbase.html
+++ b/docs/0.6.2/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/hdfs.html
+++ b/docs/0.6.2/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/hive.html
+++ b/docs/0.6.2/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/ignite.html
+++ b/docs/0.6.2/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/jdbc.html
+++ b/docs/0.6.2/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/lens.html
+++ b/docs/0.6.2/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/livy.html
+++ b/docs/0.6.2/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/markdown.html
+++ b/docs/0.6.2/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/postgresql.html
+++ b/docs/0.6.2/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/python.html
+++ b/docs/0.6.2/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/r.html
+++ b/docs/0.6.2/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/scalding.html
+++ b/docs/0.6.2/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/interpreter/spark.html
+++ b/docs/0.6.2/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/dependencymanagement.html
+++ b/docs/0.6.2/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/dynamicform.html
+++ b/docs/0.6.2/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/dynamicinterpreterload.html
+++ b/docs/0.6.2/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/interpreterinstallation.html
+++ b/docs/0.6.2/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/interpreters.html
+++ b/docs/0.6.2/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/notebookashomepage.html
+++ b/docs/0.6.2/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/manual/publish.html
+++ b/docs/0.6.2/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/pleasecontribute.html
+++ b/docs/0.6.2/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/quickstart/explorezeppelinui.html
+++ b/docs/0.6.2/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/quickstart/tutorial.html
+++ b/docs/0.6.2/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/rest-api/rest-configuration.html
+++ b/docs/0.6.2/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/rest-api/rest-interpreter.html
+++ b/docs/0.6.2/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/rest-api/rest-notebook.html
+++ b/docs/0.6.2/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/screenshots.html
+++ b/docs/0.6.2/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/security/authentication.html
+++ b/docs/0.6.2/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/security/interpreter_authorization.html
+++ b/docs/0.6.2/security/interpreter_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/security/notebook_authorization.html
+++ b/docs/0.6.2/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/security/shiroauthentication.html
+++ b/docs/0.6.2/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.6.2/storage/storage.html
+++ b/docs/0.6.2/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.6.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/development/howtocontribute.html
+++ b/docs/0.7.0/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/development/howtocontributewebsite.html
+++ b/docs/0.7.0/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/development/writingzeppelinapplication.html
+++ b/docs/0.7.0/development/writingzeppelinapplication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/development/writingzeppelininterpreter.html
+++ b/docs/0.7.0/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/development/writingzeppelinvisualization.html
+++ b/docs/0.7.0/development/writingzeppelinvisualization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/displaysystem/back-end-angular.html
+++ b/docs/0.7.0/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/displaysystem/basicdisplaysystem.html
+++ b/docs/0.7.0/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/displaysystem/front-end-angular.html
+++ b/docs/0.7.0/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/index.html
+++ b/docs/0.7.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/build.html
+++ b/docs/0.7.0/install/build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/cdh.html
+++ b/docs/0.7.0/install/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/configuration.html
+++ b/docs/0.7.0/install/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/docker.html
+++ b/docs/0.7.0/install/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/install.html
+++ b/docs/0.7.0/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/spark_cluster_mode.html
+++ b/docs/0.7.0/install/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/upgrade.html
+++ b/docs/0.7.0/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/virtual_machine.html
+++ b/docs/0.7.0/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/install/yarn_install.html
+++ b/docs/0.7.0/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/alluxio.html
+++ b/docs/0.7.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/beam.html
+++ b/docs/0.7.0/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/bigquery.html
+++ b/docs/0.7.0/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/cassandra.html
+++ b/docs/0.7.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/elasticsearch.html
+++ b/docs/0.7.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/flink.html
+++ b/docs/0.7.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/geode.html
+++ b/docs/0.7.0/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/hbase.html
+++ b/docs/0.7.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/hdfs.html
+++ b/docs/0.7.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/hive.html
+++ b/docs/0.7.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/ignite.html
+++ b/docs/0.7.0/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/jdbc.html
+++ b/docs/0.7.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/kylin.html
+++ b/docs/0.7.0/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/lens.html
+++ b/docs/0.7.0/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/livy.html
+++ b/docs/0.7.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/mahout.html
+++ b/docs/0.7.0/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/markdown.html
+++ b/docs/0.7.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/pig.html
+++ b/docs/0.7.0/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/postgresql.html
+++ b/docs/0.7.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/python.html
+++ b/docs/0.7.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/r.html
+++ b/docs/0.7.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/scalding.html
+++ b/docs/0.7.0/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/scio.html
+++ b/docs/0.7.0/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/shell.html
+++ b/docs/0.7.0/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/interpreter/spark.html
+++ b/docs/0.7.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/dependencymanagement.html
+++ b/docs/0.7.0/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/dynamicform.html
+++ b/docs/0.7.0/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/dynamicinterpreterload.html
+++ b/docs/0.7.0/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/interpreterexechooks.html
+++ b/docs/0.7.0/manual/interpreterexechooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/interpreterinstallation.html
+++ b/docs/0.7.0/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/interpreters.html
+++ b/docs/0.7.0/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/notebookashomepage.html
+++ b/docs/0.7.0/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/publish.html
+++ b/docs/0.7.0/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/manual/userimpersonation.html
+++ b/docs/0.7.0/manual/userimpersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/pleasecontribute.html
+++ b/docs/0.7.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/quickstart/explorezeppelinui.html
+++ b/docs/0.7.0/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/quickstart/install_with_flink_and_spark_cluster.html
+++ b/docs/0.7.0/quickstart/install_with_flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/quickstart/tutorial.html
+++ b/docs/0.7.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/rest-api/rest-configuration.html
+++ b/docs/0.7.0/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/rest-api/rest-credential.html
+++ b/docs/0.7.0/rest-api/rest-credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/rest-api/rest-helium.html
+++ b/docs/0.7.0/rest-api/rest-helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/rest-api/rest-interpreter.html
+++ b/docs/0.7.0/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/rest-api/rest-notebook.html
+++ b/docs/0.7.0/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/screenshots.html
+++ b/docs/0.7.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/search.html
+++ b/docs/0.7.0/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/security/authentication.html
+++ b/docs/0.7.0/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/security/datasource_authorization.html
+++ b/docs/0.7.0/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/security/notebook_authorization.html
+++ b/docs/0.7.0/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/security/shiroauthentication.html
+++ b/docs/0.7.0/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.0/storage/storage.html
+++ b/docs/0.7.0/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/development/howtocontribute.html
+++ b/docs/0.7.1/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/development/howtocontributewebsite.html
+++ b/docs/0.7.1/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/development/writingzeppelinapplication.html
+++ b/docs/0.7.1/development/writingzeppelinapplication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/development/writingzeppelininterpreter.html
+++ b/docs/0.7.1/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/development/writingzeppelinvisualization.html
+++ b/docs/0.7.1/development/writingzeppelinvisualization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/displaysystem/back-end-angular.html
+++ b/docs/0.7.1/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/displaysystem/basicdisplaysystem.html
+++ b/docs/0.7.1/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/displaysystem/front-end-angular.html
+++ b/docs/0.7.1/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/index.html
+++ b/docs/0.7.1/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/build.html
+++ b/docs/0.7.1/install/build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/cdh.html
+++ b/docs/0.7.1/install/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/configuration.html
+++ b/docs/0.7.1/install/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/docker.html
+++ b/docs/0.7.1/install/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/install.html
+++ b/docs/0.7.1/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/spark_cluster_mode.html
+++ b/docs/0.7.1/install/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/upgrade.html
+++ b/docs/0.7.1/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/virtual_machine.html
+++ b/docs/0.7.1/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/install/yarn_install.html
+++ b/docs/0.7.1/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/alluxio.html
+++ b/docs/0.7.1/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/beam.html
+++ b/docs/0.7.1/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/bigquery.html
+++ b/docs/0.7.1/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/cassandra.html
+++ b/docs/0.7.1/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/elasticsearch.html
+++ b/docs/0.7.1/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/flink.html
+++ b/docs/0.7.1/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/geode.html
+++ b/docs/0.7.1/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/hbase.html
+++ b/docs/0.7.1/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/hdfs.html
+++ b/docs/0.7.1/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/hive.html
+++ b/docs/0.7.1/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/ignite.html
+++ b/docs/0.7.1/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/jdbc.html
+++ b/docs/0.7.1/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/kylin.html
+++ b/docs/0.7.1/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/lens.html
+++ b/docs/0.7.1/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/livy.html
+++ b/docs/0.7.1/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/mahout.html
+++ b/docs/0.7.1/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/markdown.html
+++ b/docs/0.7.1/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/pig.html
+++ b/docs/0.7.1/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/postgresql.html
+++ b/docs/0.7.1/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/python.html
+++ b/docs/0.7.1/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/r.html
+++ b/docs/0.7.1/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/scalding.html
+++ b/docs/0.7.1/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/scio.html
+++ b/docs/0.7.1/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/shell.html
+++ b/docs/0.7.1/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/interpreter/spark.html
+++ b/docs/0.7.1/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/dependencymanagement.html
+++ b/docs/0.7.1/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/dynamicform.html
+++ b/docs/0.7.1/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/dynamicinterpreterload.html
+++ b/docs/0.7.1/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/interpreterexechooks.html
+++ b/docs/0.7.1/manual/interpreterexechooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/interpreterinstallation.html
+++ b/docs/0.7.1/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/interpreters.html
+++ b/docs/0.7.1/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/notebookashomepage.html
+++ b/docs/0.7.1/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/publish.html
+++ b/docs/0.7.1/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/manual/userimpersonation.html
+++ b/docs/0.7.1/manual/userimpersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/pleasecontribute.html
+++ b/docs/0.7.1/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/quickstart/explorezeppelinui.html
+++ b/docs/0.7.1/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/quickstart/install_with_flink_and_spark_cluster.html
+++ b/docs/0.7.1/quickstart/install_with_flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/quickstart/tutorial.html
+++ b/docs/0.7.1/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-configuration.html
+++ b/docs/0.7.1/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-credential.html
+++ b/docs/0.7.1/rest-api/rest-credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-helium.html
+++ b/docs/0.7.1/rest-api/rest-helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-interpreter.html
+++ b/docs/0.7.1/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-notebook.html
+++ b/docs/0.7.1/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/rest-api/rest-notebookRepo.html
+++ b/docs/0.7.1/rest-api/rest-notebookRepo.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/screenshots.html
+++ b/docs/0.7.1/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/search.html
+++ b/docs/0.7.1/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/security/authentication.html
+++ b/docs/0.7.1/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/security/datasource_authorization.html
+++ b/docs/0.7.1/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/security/notebook_authorization.html
+++ b/docs/0.7.1/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/security/shiroauthentication.html
+++ b/docs/0.7.1/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.1/storage/storage.html
+++ b/docs/0.7.1/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/development/howtocontribute.html
+++ b/docs/0.7.2/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/development/howtocontributewebsite.html
+++ b/docs/0.7.2/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/development/writingzeppelinapplication.html
+++ b/docs/0.7.2/development/writingzeppelinapplication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/development/writingzeppelininterpreter.html
+++ b/docs/0.7.2/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/development/writingzeppelinvisualization.html
+++ b/docs/0.7.2/development/writingzeppelinvisualization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/displaysystem/back-end-angular.html
+++ b/docs/0.7.2/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/displaysystem/basicdisplaysystem.html
+++ b/docs/0.7.2/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/displaysystem/front-end-angular.html
+++ b/docs/0.7.2/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/index.html
+++ b/docs/0.7.2/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/build.html
+++ b/docs/0.7.2/install/build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/cdh.html
+++ b/docs/0.7.2/install/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/configuration.html
+++ b/docs/0.7.2/install/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/docker.html
+++ b/docs/0.7.2/install/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/install.html
+++ b/docs/0.7.2/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/spark_cluster_mode.html
+++ b/docs/0.7.2/install/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/upgrade.html
+++ b/docs/0.7.2/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/virtual_machine.html
+++ b/docs/0.7.2/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/install/yarn_install.html
+++ b/docs/0.7.2/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/alluxio.html
+++ b/docs/0.7.2/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/beam.html
+++ b/docs/0.7.2/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/bigquery.html
+++ b/docs/0.7.2/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/cassandra.html
+++ b/docs/0.7.2/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/elasticsearch.html
+++ b/docs/0.7.2/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/flink.html
+++ b/docs/0.7.2/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/geode.html
+++ b/docs/0.7.2/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/hbase.html
+++ b/docs/0.7.2/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/hdfs.html
+++ b/docs/0.7.2/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/hive.html
+++ b/docs/0.7.2/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/ignite.html
+++ b/docs/0.7.2/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/jdbc.html
+++ b/docs/0.7.2/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/kylin.html
+++ b/docs/0.7.2/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/lens.html
+++ b/docs/0.7.2/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/livy.html
+++ b/docs/0.7.2/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/mahout.html
+++ b/docs/0.7.2/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/markdown.html
+++ b/docs/0.7.2/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/pig.html
+++ b/docs/0.7.2/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/postgresql.html
+++ b/docs/0.7.2/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/python.html
+++ b/docs/0.7.2/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/r.html
+++ b/docs/0.7.2/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/scalding.html
+++ b/docs/0.7.2/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/scio.html
+++ b/docs/0.7.2/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/shell.html
+++ b/docs/0.7.2/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/interpreter/spark.html
+++ b/docs/0.7.2/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/dependencymanagement.html
+++ b/docs/0.7.2/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/dynamicform.html
+++ b/docs/0.7.2/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/dynamicinterpreterload.html
+++ b/docs/0.7.2/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/interpreterexechooks.html
+++ b/docs/0.7.2/manual/interpreterexechooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/interpreterinstallation.html
+++ b/docs/0.7.2/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/interpreters.html
+++ b/docs/0.7.2/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/notebookashomepage.html
+++ b/docs/0.7.2/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/publish.html
+++ b/docs/0.7.2/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/manual/userimpersonation.html
+++ b/docs/0.7.2/manual/userimpersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/pleasecontribute.html
+++ b/docs/0.7.2/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/quickstart/explorezeppelinui.html
+++ b/docs/0.7.2/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/quickstart/install_with_flink_and_spark_cluster.html
+++ b/docs/0.7.2/quickstart/install_with_flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/quickstart/tutorial.html
+++ b/docs/0.7.2/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-configuration.html
+++ b/docs/0.7.2/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-credential.html
+++ b/docs/0.7.2/rest-api/rest-credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-helium.html
+++ b/docs/0.7.2/rest-api/rest-helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-interpreter.html
+++ b/docs/0.7.2/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-notebook.html
+++ b/docs/0.7.2/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/rest-api/rest-notebookRepo.html
+++ b/docs/0.7.2/rest-api/rest-notebookRepo.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/screenshots.html
+++ b/docs/0.7.2/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/search.html
+++ b/docs/0.7.2/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/security/authentication.html
+++ b/docs/0.7.2/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/security/datasource_authorization.html
+++ b/docs/0.7.2/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/security/helium_authorization.html
+++ b/docs/0.7.2/security/helium_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/security/notebook_authorization.html
+++ b/docs/0.7.2/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/security/shiroauthentication.html
+++ b/docs/0.7.2/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.2/storage/storage.html
+++ b/docs/0.7.2/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/development/howtocontribute.html
+++ b/docs/0.7.3/development/howtocontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/development/howtocontributewebsite.html
+++ b/docs/0.7.3/development/howtocontributewebsite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/development/writingzeppelinapplication.html
+++ b/docs/0.7.3/development/writingzeppelinapplication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/development/writingzeppelininterpreter.html
+++ b/docs/0.7.3/development/writingzeppelininterpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/development/writingzeppelinvisualization.html
+++ b/docs/0.7.3/development/writingzeppelinvisualization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/displaysystem/back-end-angular.html
+++ b/docs/0.7.3/displaysystem/back-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/displaysystem/basicdisplaysystem.html
+++ b/docs/0.7.3/displaysystem/basicdisplaysystem.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/displaysystem/front-end-angular.html
+++ b/docs/0.7.3/displaysystem/front-end-angular.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/index.html
+++ b/docs/0.7.3/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/build.html
+++ b/docs/0.7.3/install/build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/cdh.html
+++ b/docs/0.7.3/install/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/configuration.html
+++ b/docs/0.7.3/install/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/docker.html
+++ b/docs/0.7.3/install/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/install.html
+++ b/docs/0.7.3/install/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/spark_cluster_mode.html
+++ b/docs/0.7.3/install/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/upgrade.html
+++ b/docs/0.7.3/install/upgrade.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/virtual_machine.html
+++ b/docs/0.7.3/install/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/install/yarn_install.html
+++ b/docs/0.7.3/install/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/alluxio.html
+++ b/docs/0.7.3/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/beam.html
+++ b/docs/0.7.3/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/bigquery.html
+++ b/docs/0.7.3/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/cassandra.html
+++ b/docs/0.7.3/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/elasticsearch.html
+++ b/docs/0.7.3/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/flink.html
+++ b/docs/0.7.3/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/geode.html
+++ b/docs/0.7.3/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/hbase.html
+++ b/docs/0.7.3/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/hdfs.html
+++ b/docs/0.7.3/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/hive.html
+++ b/docs/0.7.3/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/ignite.html
+++ b/docs/0.7.3/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/jdbc.html
+++ b/docs/0.7.3/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/kylin.html
+++ b/docs/0.7.3/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/lens.html
+++ b/docs/0.7.3/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/livy.html
+++ b/docs/0.7.3/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/mahout.html
+++ b/docs/0.7.3/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/markdown.html
+++ b/docs/0.7.3/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/pig.html
+++ b/docs/0.7.3/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/postgresql.html
+++ b/docs/0.7.3/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/python.html
+++ b/docs/0.7.3/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/r.html
+++ b/docs/0.7.3/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/scalding.html
+++ b/docs/0.7.3/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/scio.html
+++ b/docs/0.7.3/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/shell.html
+++ b/docs/0.7.3/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/interpreter/spark.html
+++ b/docs/0.7.3/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/dependencymanagement.html
+++ b/docs/0.7.3/manual/dependencymanagement.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/dynamicform.html
+++ b/docs/0.7.3/manual/dynamicform.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/dynamicinterpreterload.html
+++ b/docs/0.7.3/manual/dynamicinterpreterload.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/interpreterexechooks.html
+++ b/docs/0.7.3/manual/interpreterexechooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/interpreterinstallation.html
+++ b/docs/0.7.3/manual/interpreterinstallation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/interpreters.html
+++ b/docs/0.7.3/manual/interpreters.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/notebookashomepage.html
+++ b/docs/0.7.3/manual/notebookashomepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/publish.html
+++ b/docs/0.7.3/manual/publish.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/manual/userimpersonation.html
+++ b/docs/0.7.3/manual/userimpersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/pleasecontribute.html
+++ b/docs/0.7.3/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/quickstart/explorezeppelinui.html
+++ b/docs/0.7.3/quickstart/explorezeppelinui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/quickstart/install_with_flink_and_spark_cluster.html
+++ b/docs/0.7.3/quickstart/install_with_flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/quickstart/tutorial.html
+++ b/docs/0.7.3/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-configuration.html
+++ b/docs/0.7.3/rest-api/rest-configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-credential.html
+++ b/docs/0.7.3/rest-api/rest-credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-helium.html
+++ b/docs/0.7.3/rest-api/rest-helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-interpreter.html
+++ b/docs/0.7.3/rest-api/rest-interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-notebook.html
+++ b/docs/0.7.3/rest-api/rest-notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/rest-api/rest-notebookRepo.html
+++ b/docs/0.7.3/rest-api/rest-notebookRepo.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/screenshots.html
+++ b/docs/0.7.3/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/search.html
+++ b/docs/0.7.3/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/authentication.html
+++ b/docs/0.7.3/security/authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/datasource_authorization.html
+++ b/docs/0.7.3/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/helium_authorization.html
+++ b/docs/0.7.3/security/helium_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/http_security_headers.html
+++ b/docs/0.7.3/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/notebook_authorization.html
+++ b/docs/0.7.3/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/security/shiroauthentication.html
+++ b/docs/0.7.3/security/shiroauthentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.7.3/storage/storage.html
+++ b/docs/0.7.3/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.7.3/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/contribution/how_to_contribute_code.html
+++ b/docs/0.8.0/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/contribution/how_to_contribute_website.html
+++ b/docs/0.8.0/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/contribution/useful_developer_tools.html
+++ b/docs/0.8.0/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/helium/overview.html
+++ b/docs/0.8.0/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/helium/writing_application.html
+++ b/docs/0.8.0/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/helium/writing_spell.html
+++ b/docs/0.8.0/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/helium/writing_visualization_basic.html
+++ b/docs/0.8.0/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/helium/writing_visualization_transformation.html
+++ b/docs/0.8.0/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/development/writing_zeppelin_interpreter.html
+++ b/docs/0.8.0/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/index.html
+++ b/docs/0.8.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/alluxio.html
+++ b/docs/0.8.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/beam.html
+++ b/docs/0.8.0/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/bigquery.html
+++ b/docs/0.8.0/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/cassandra.html
+++ b/docs/0.8.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/elasticsearch.html
+++ b/docs/0.8.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/flink.html
+++ b/docs/0.8.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/geode.html
+++ b/docs/0.8.0/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/groovy.html
+++ b/docs/0.8.0/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/hbase.html
+++ b/docs/0.8.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/hdfs.html
+++ b/docs/0.8.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/hive.html
+++ b/docs/0.8.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/ignite.html
+++ b/docs/0.8.0/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/jdbc.html
+++ b/docs/0.8.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/kylin.html
+++ b/docs/0.8.0/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/lens.html
+++ b/docs/0.8.0/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/livy.html
+++ b/docs/0.8.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/mahout.html
+++ b/docs/0.8.0/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/markdown.html
+++ b/docs/0.8.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/neo4j.html
+++ b/docs/0.8.0/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/pig.html
+++ b/docs/0.8.0/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/postgresql.html
+++ b/docs/0.8.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/python.html
+++ b/docs/0.8.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/r.html
+++ b/docs/0.8.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/sap.html
+++ b/docs/0.8.0/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/scalding.html
+++ b/docs/0.8.0/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/scio.html
+++ b/docs/0.8.0/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/shell.html
+++ b/docs/0.8.0/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/interpreter/spark.html
+++ b/docs/0.8.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/pleasecontribute.html
+++ b/docs/0.8.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/explore_ui.html
+++ b/docs/0.8.0/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/install.html
+++ b/docs/0.8.0/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/python_with_zeppelin.html
+++ b/docs/0.8.0/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/spark_with_zeppelin.html
+++ b/docs/0.8.0/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/sql_with_zeppelin.html
+++ b/docs/0.8.0/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/quickstart/tutorial.html
+++ b/docs/0.8.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/screenshots.html
+++ b/docs/0.8.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/search.html
+++ b/docs/0.8.0/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/basics/how_to_build.html
+++ b/docs/0.8.0/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/basics/multi_user_support.html
+++ b/docs/0.8.0/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/cdh.html
+++ b/docs/0.8.0/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/docker.html
+++ b/docs/0.8.0/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.8.0/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.8.0/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/virtual_machine.html
+++ b/docs/0.8.0/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/deployment/yarn_install.html
+++ b/docs/0.8.0/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/operation/configuration.html
+++ b/docs/0.8.0/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/operation/proxy_setting.html
+++ b/docs/0.8.0/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/operation/trouble_shooting.html
+++ b/docs/0.8.0/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/operation/upgrading.html
+++ b/docs/0.8.0/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/security/authentication_nginx.html
+++ b/docs/0.8.0/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/security/datasource_authorization.html
+++ b/docs/0.8.0/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/security/http_security_headers.html
+++ b/docs/0.8.0/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/security/notebook_authorization.html
+++ b/docs/0.8.0/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/security/shiro_authentication.html
+++ b/docs/0.8.0/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/setup/storage/storage.html
+++ b/docs/0.8.0/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/display_system/angular_backend.html
+++ b/docs/0.8.0/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/display_system/angular_frontend.html
+++ b/docs/0.8.0/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/display_system/basic.html
+++ b/docs/0.8.0/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/dynamic_form/intro.html
+++ b/docs/0.8.0/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/dependency_management.html
+++ b/docs/0.8.0/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/dynamic_loading.html
+++ b/docs/0.8.0/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/execution_hooks.html
+++ b/docs/0.8.0/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/installation.html
+++ b/docs/0.8.0/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.8.0/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/overview.html
+++ b/docs/0.8.0/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/interpreter/user_impersonation.html
+++ b/docs/0.8.0/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/cron_scheduler.html
+++ b/docs/0.8.0/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/customizing_homepage.html
+++ b/docs/0.8.0/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/notebook_actions.html
+++ b/docs/0.8.0/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/personalized_mode.html
+++ b/docs/0.8.0/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.8.0/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/other_features/zeppelin_context.html
+++ b/docs/0.8.0/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/configuration.html
+++ b/docs/0.8.0/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/credential.html
+++ b/docs/0.8.0/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/helium.html
+++ b/docs/0.8.0/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/interpreter.html
+++ b/docs/0.8.0/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/notebook.html
+++ b/docs/0.8.0/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/notebook_repository.html
+++ b/docs/0.8.0/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.0/usage/rest_api/zeppelin_server.html
+++ b/docs/0.8.0/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/contribution/how_to_contribute_code.html
+++ b/docs/0.8.1/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/contribution/how_to_contribute_website.html
+++ b/docs/0.8.1/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/contribution/useful_developer_tools.html
+++ b/docs/0.8.1/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/helium/overview.html
+++ b/docs/0.8.1/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/helium/writing_application.html
+++ b/docs/0.8.1/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/helium/writing_spell.html
+++ b/docs/0.8.1/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/helium/writing_visualization_basic.html
+++ b/docs/0.8.1/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/helium/writing_visualization_transformation.html
+++ b/docs/0.8.1/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/development/writing_zeppelin_interpreter.html
+++ b/docs/0.8.1/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/index.html
+++ b/docs/0.8.1/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/alluxio.html
+++ b/docs/0.8.1/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/beam.html
+++ b/docs/0.8.1/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/bigquery.html
+++ b/docs/0.8.1/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/cassandra.html
+++ b/docs/0.8.1/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/elasticsearch.html
+++ b/docs/0.8.1/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/flink.html
+++ b/docs/0.8.1/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/geode.html
+++ b/docs/0.8.1/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/groovy.html
+++ b/docs/0.8.1/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/hbase.html
+++ b/docs/0.8.1/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/hdfs.html
+++ b/docs/0.8.1/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/hive.html
+++ b/docs/0.8.1/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/ignite.html
+++ b/docs/0.8.1/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/jdbc.html
+++ b/docs/0.8.1/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/kylin.html
+++ b/docs/0.8.1/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/lens.html
+++ b/docs/0.8.1/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/livy.html
+++ b/docs/0.8.1/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/mahout.html
+++ b/docs/0.8.1/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/markdown.html
+++ b/docs/0.8.1/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/neo4j.html
+++ b/docs/0.8.1/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/pig.html
+++ b/docs/0.8.1/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/postgresql.html
+++ b/docs/0.8.1/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/python.html
+++ b/docs/0.8.1/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/r.html
+++ b/docs/0.8.1/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/sap.html
+++ b/docs/0.8.1/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/scalding.html
+++ b/docs/0.8.1/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/scio.html
+++ b/docs/0.8.1/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/shell.html
+++ b/docs/0.8.1/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/interpreter/spark.html
+++ b/docs/0.8.1/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/pleasecontribute.html
+++ b/docs/0.8.1/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/explore_ui.html
+++ b/docs/0.8.1/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/install.html
+++ b/docs/0.8.1/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/python_with_zeppelin.html
+++ b/docs/0.8.1/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/spark_with_zeppelin.html
+++ b/docs/0.8.1/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/sql_with_zeppelin.html
+++ b/docs/0.8.1/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/quickstart/tutorial.html
+++ b/docs/0.8.1/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/screenshots.html
+++ b/docs/0.8.1/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/search.html
+++ b/docs/0.8.1/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/basics/how_to_build.html
+++ b/docs/0.8.1/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/basics/multi_user_support.html
+++ b/docs/0.8.1/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/cdh.html
+++ b/docs/0.8.1/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/docker.html
+++ b/docs/0.8.1/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.8.1/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.8.1/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/virtual_machine.html
+++ b/docs/0.8.1/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/deployment/yarn_install.html
+++ b/docs/0.8.1/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/operation/configuration.html
+++ b/docs/0.8.1/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/operation/proxy_setting.html
+++ b/docs/0.8.1/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/operation/trouble_shooting.html
+++ b/docs/0.8.1/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/operation/upgrading.html
+++ b/docs/0.8.1/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/security/authentication_nginx.html
+++ b/docs/0.8.1/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/security/datasource_authorization.html
+++ b/docs/0.8.1/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/security/http_security_headers.html
+++ b/docs/0.8.1/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/security/notebook_authorization.html
+++ b/docs/0.8.1/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/security/shiro_authentication.html
+++ b/docs/0.8.1/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/setup/storage/storage.html
+++ b/docs/0.8.1/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/display_system/angular_backend.html
+++ b/docs/0.8.1/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/display_system/angular_frontend.html
+++ b/docs/0.8.1/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/display_system/basic.html
+++ b/docs/0.8.1/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/dynamic_form/intro.html
+++ b/docs/0.8.1/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/dependency_management.html
+++ b/docs/0.8.1/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/dynamic_loading.html
+++ b/docs/0.8.1/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/execution_hooks.html
+++ b/docs/0.8.1/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/installation.html
+++ b/docs/0.8.1/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.8.1/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/overview.html
+++ b/docs/0.8.1/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/interpreter/user_impersonation.html
+++ b/docs/0.8.1/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/cron_scheduler.html
+++ b/docs/0.8.1/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/customizing_homepage.html
+++ b/docs/0.8.1/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/notebook_actions.html
+++ b/docs/0.8.1/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/personalized_mode.html
+++ b/docs/0.8.1/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.8.1/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/other_features/zeppelin_context.html
+++ b/docs/0.8.1/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/configuration.html
+++ b/docs/0.8.1/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/credential.html
+++ b/docs/0.8.1/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/helium.html
+++ b/docs/0.8.1/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/interpreter.html
+++ b/docs/0.8.1/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/notebook.html
+++ b/docs/0.8.1/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/notebook_repository.html
+++ b/docs/0.8.1/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.1/usage/rest_api/zeppelin_server.html
+++ b/docs/0.8.1/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.1/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/contribution/how_to_contribute_code.html
+++ b/docs/0.8.2/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/contribution/how_to_contribute_website.html
+++ b/docs/0.8.2/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/contribution/useful_developer_tools.html
+++ b/docs/0.8.2/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/helium/overview.html
+++ b/docs/0.8.2/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/helium/writing_application.html
+++ b/docs/0.8.2/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/helium/writing_spell.html
+++ b/docs/0.8.2/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/helium/writing_visualization_basic.html
+++ b/docs/0.8.2/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/helium/writing_visualization_transformation.html
+++ b/docs/0.8.2/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/development/writing_zeppelin_interpreter.html
+++ b/docs/0.8.2/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/index.html
+++ b/docs/0.8.2/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/alluxio.html
+++ b/docs/0.8.2/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/beam.html
+++ b/docs/0.8.2/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/bigquery.html
+++ b/docs/0.8.2/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/cassandra.html
+++ b/docs/0.8.2/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/elasticsearch.html
+++ b/docs/0.8.2/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/flink.html
+++ b/docs/0.8.2/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/geode.html
+++ b/docs/0.8.2/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/groovy.html
+++ b/docs/0.8.2/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/hbase.html
+++ b/docs/0.8.2/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/hdfs.html
+++ b/docs/0.8.2/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/hive.html
+++ b/docs/0.8.2/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/ignite.html
+++ b/docs/0.8.2/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/jdbc.html
+++ b/docs/0.8.2/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/kylin.html
+++ b/docs/0.8.2/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/lens.html
+++ b/docs/0.8.2/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/livy.html
+++ b/docs/0.8.2/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/mahout.html
+++ b/docs/0.8.2/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/markdown.html
+++ b/docs/0.8.2/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/neo4j.html
+++ b/docs/0.8.2/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/pig.html
+++ b/docs/0.8.2/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/postgresql.html
+++ b/docs/0.8.2/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/python.html
+++ b/docs/0.8.2/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/r.html
+++ b/docs/0.8.2/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/sap.html
+++ b/docs/0.8.2/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/scalding.html
+++ b/docs/0.8.2/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/scio.html
+++ b/docs/0.8.2/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/shell.html
+++ b/docs/0.8.2/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/interpreter/spark.html
+++ b/docs/0.8.2/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/pleasecontribute.html
+++ b/docs/0.8.2/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/explore_ui.html
+++ b/docs/0.8.2/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/install.html
+++ b/docs/0.8.2/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/python_with_zeppelin.html
+++ b/docs/0.8.2/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/spark_with_zeppelin.html
+++ b/docs/0.8.2/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/sql_with_zeppelin.html
+++ b/docs/0.8.2/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/quickstart/tutorial.html
+++ b/docs/0.8.2/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/screenshots.html
+++ b/docs/0.8.2/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/search.html
+++ b/docs/0.8.2/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/basics/how_to_build.html
+++ b/docs/0.8.2/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/basics/multi_user_support.html
+++ b/docs/0.8.2/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/cdh.html
+++ b/docs/0.8.2/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/docker.html
+++ b/docs/0.8.2/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.8.2/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.8.2/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/virtual_machine.html
+++ b/docs/0.8.2/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/deployment/yarn_install.html
+++ b/docs/0.8.2/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/operation/configuration.html
+++ b/docs/0.8.2/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/operation/proxy_setting.html
+++ b/docs/0.8.2/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/operation/trouble_shooting.html
+++ b/docs/0.8.2/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/operation/upgrading.html
+++ b/docs/0.8.2/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/security/authentication_nginx.html
+++ b/docs/0.8.2/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/security/datasource_authorization.html
+++ b/docs/0.8.2/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/security/http_security_headers.html
+++ b/docs/0.8.2/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/security/notebook_authorization.html
+++ b/docs/0.8.2/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/security/shiro_authentication.html
+++ b/docs/0.8.2/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/setup/storage/storage.html
+++ b/docs/0.8.2/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/display_system/angular_backend.html
+++ b/docs/0.8.2/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/display_system/angular_frontend.html
+++ b/docs/0.8.2/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/display_system/basic.html
+++ b/docs/0.8.2/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/dynamic_form/intro.html
+++ b/docs/0.8.2/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/dependency_management.html
+++ b/docs/0.8.2/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/dynamic_loading.html
+++ b/docs/0.8.2/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/execution_hooks.html
+++ b/docs/0.8.2/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/installation.html
+++ b/docs/0.8.2/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.8.2/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/overview.html
+++ b/docs/0.8.2/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/interpreter/user_impersonation.html
+++ b/docs/0.8.2/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/cron_scheduler.html
+++ b/docs/0.8.2/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/customizing_homepage.html
+++ b/docs/0.8.2/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/notebook_actions.html
+++ b/docs/0.8.2/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/personalized_mode.html
+++ b/docs/0.8.2/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.8.2/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/other_features/zeppelin_context.html
+++ b/docs/0.8.2/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/configuration.html
+++ b/docs/0.8.2/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/credential.html
+++ b/docs/0.8.2/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/helium.html
+++ b/docs/0.8.2/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/interpreter.html
+++ b/docs/0.8.2/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/notebook.html
+++ b/docs/0.8.2/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/notebook_repository.html
+++ b/docs/0.8.2/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.8.2/usage/rest_api/zeppelin_server.html
+++ b/docs/0.8.2/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.8.2/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/contribution/how_to_contribute_code.html
+++ b/docs/0.9.0/development/contribution/how_to_contribute_code.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/contribution/how_to_contribute_website.html
+++ b/docs/0.9.0/development/contribution/how_to_contribute_website.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/contribution/useful_developer_tools.html
+++ b/docs/0.9.0/development/contribution/useful_developer_tools.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/helium/overview.html
+++ b/docs/0.9.0/development/helium/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/helium/writing_application.html
+++ b/docs/0.9.0/development/helium/writing_application.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/helium/writing_spell.html
+++ b/docs/0.9.0/development/helium/writing_spell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/helium/writing_visualization_basic.html
+++ b/docs/0.9.0/development/helium/writing_visualization_basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/helium/writing_visualization_transformation.html
+++ b/docs/0.9.0/development/helium/writing_visualization_transformation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/development/writing_zeppelin_interpreter.html
+++ b/docs/0.9.0/development/writing_zeppelin_interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/index.html
+++ b/docs/0.9.0/index.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/alluxio.html
+++ b/docs/0.9.0/interpreter/alluxio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/beam.html
+++ b/docs/0.9.0/interpreter/beam.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/bigquery.html
+++ b/docs/0.9.0/interpreter/bigquery.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/cassandra.html
+++ b/docs/0.9.0/interpreter/cassandra.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/elasticsearch.html
+++ b/docs/0.9.0/interpreter/elasticsearch.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/flink.html
+++ b/docs/0.9.0/interpreter/flink.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/geode.html
+++ b/docs/0.9.0/interpreter/geode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/groovy.html
+++ b/docs/0.9.0/interpreter/groovy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/hazelcastjet.html
+++ b/docs/0.9.0/interpreter/hazelcastjet.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/hbase.html
+++ b/docs/0.9.0/interpreter/hbase.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/hdfs.html
+++ b/docs/0.9.0/interpreter/hdfs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/hive.html
+++ b/docs/0.9.0/interpreter/hive.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/ignite.html
+++ b/docs/0.9.0/interpreter/ignite.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/influxdb.html
+++ b/docs/0.9.0/interpreter/influxdb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/java.html
+++ b/docs/0.9.0/interpreter/java.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/jdbc.html
+++ b/docs/0.9.0/interpreter/jdbc.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/jupyter.html
+++ b/docs/0.9.0/interpreter/jupyter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/kotlin.html
+++ b/docs/0.9.0/interpreter/kotlin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/ksql.html
+++ b/docs/0.9.0/interpreter/ksql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/kylin.html
+++ b/docs/0.9.0/interpreter/kylin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/lens.html
+++ b/docs/0.9.0/interpreter/lens.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/livy.html
+++ b/docs/0.9.0/interpreter/livy.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/mahout.html
+++ b/docs/0.9.0/interpreter/mahout.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/markdown.html
+++ b/docs/0.9.0/interpreter/markdown.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/mongodb.html
+++ b/docs/0.9.0/interpreter/mongodb.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/neo4j.html
+++ b/docs/0.9.0/interpreter/neo4j.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/pig.html
+++ b/docs/0.9.0/interpreter/pig.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/postgresql.html
+++ b/docs/0.9.0/interpreter/postgresql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/python.html
+++ b/docs/0.9.0/interpreter/python.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/r.html
+++ b/docs/0.9.0/interpreter/r.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/sap.html
+++ b/docs/0.9.0/interpreter/sap.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/scalding.html
+++ b/docs/0.9.0/interpreter/scalding.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/scio.html
+++ b/docs/0.9.0/interpreter/scio.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/shell.html
+++ b/docs/0.9.0/interpreter/shell.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/spark.html
+++ b/docs/0.9.0/interpreter/spark.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/sparql.html
+++ b/docs/0.9.0/interpreter/sparql.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/interpreter/submarine.html
+++ b/docs/0.9.0/interpreter/submarine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/pleasecontribute.html
+++ b/docs/0.9.0/pleasecontribute.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/docker.html
+++ b/docs/0.9.0/quickstart/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/explore_ui.html
+++ b/docs/0.9.0/quickstart/explore_ui.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/install.html
+++ b/docs/0.9.0/quickstart/install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/kubernetes.html
+++ b/docs/0.9.0/quickstart/kubernetes.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/python_with_zeppelin.html
+++ b/docs/0.9.0/quickstart/python_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/spark_with_zeppelin.html
+++ b/docs/0.9.0/quickstart/spark_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/sql_with_zeppelin.html
+++ b/docs/0.9.0/quickstart/sql_with_zeppelin.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/tutorial.html
+++ b/docs/0.9.0/quickstart/tutorial.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/quickstart/yarn.html
+++ b/docs/0.9.0/quickstart/yarn.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/screenshots.html
+++ b/docs/0.9.0/screenshots.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/search.html
+++ b/docs/0.9.0/search.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/basics/hadoop_integration.html
+++ b/docs/0.9.0/setup/basics/hadoop_integration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/basics/how_to_build.html
+++ b/docs/0.9.0/setup/basics/how_to_build.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/basics/multi_user_support.html
+++ b/docs/0.9.0/setup/basics/multi_user_support.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/basics/systemd.html
+++ b/docs/0.9.0/setup/basics/systemd.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/cdh.html
+++ b/docs/0.9.0/setup/deployment/cdh.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/docker.html
+++ b/docs/0.9.0/setup/deployment/docker.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/flink_and_spark_cluster.html
+++ b/docs/0.9.0/setup/deployment/flink_and_spark_cluster.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/spark_cluster_mode.html
+++ b/docs/0.9.0/setup/deployment/spark_cluster_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/virtual_machine.html
+++ b/docs/0.9.0/setup/deployment/virtual_machine.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/deployment/yarn_install.html
+++ b/docs/0.9.0/setup/deployment/yarn_install.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/operation/configuration.html
+++ b/docs/0.9.0/setup/operation/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/operation/monitoring.html
+++ b/docs/0.9.0/setup/operation/monitoring.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/operation/proxy_setting.html
+++ b/docs/0.9.0/setup/operation/proxy_setting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/operation/trouble_shooting.html
+++ b/docs/0.9.0/setup/operation/trouble_shooting.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/operation/upgrading.html
+++ b/docs/0.9.0/setup/operation/upgrading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/security/authentication_nginx.html
+++ b/docs/0.9.0/setup/security/authentication_nginx.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/security/datasource_authorization.html
+++ b/docs/0.9.0/setup/security/datasource_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/security/http_security_headers.html
+++ b/docs/0.9.0/setup/security/http_security_headers.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/security/notebook_authorization.html
+++ b/docs/0.9.0/setup/security/notebook_authorization.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/security/shiro_authentication.html
+++ b/docs/0.9.0/setup/security/shiro_authentication.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/setup/storage/storage.html
+++ b/docs/0.9.0/setup/storage/storage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/display_system/angular_backend.html
+++ b/docs/0.9.0/usage/display_system/angular_backend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/display_system/angular_frontend.html
+++ b/docs/0.9.0/usage/display_system/angular_frontend.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/display_system/basic.html
+++ b/docs/0.9.0/usage/display_system/basic.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/dynamic_form/intro.html
+++ b/docs/0.9.0/usage/dynamic_form/intro.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/dependency_management.html
+++ b/docs/0.9.0/usage/interpreter/dependency_management.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/dynamic_loading.html
+++ b/docs/0.9.0/usage/interpreter/dynamic_loading.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/execution_hooks.html
+++ b/docs/0.9.0/usage/interpreter/execution_hooks.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/installation.html
+++ b/docs/0.9.0/usage/interpreter/installation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/interpreter_binding_mode.html
+++ b/docs/0.9.0/usage/interpreter/interpreter_binding_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/overview.html
+++ b/docs/0.9.0/usage/interpreter/overview.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/interpreter/user_impersonation.html
+++ b/docs/0.9.0/usage/interpreter/user_impersonation.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/cron_scheduler.html
+++ b/docs/0.9.0/usage/other_features/cron_scheduler.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/customizing_homepage.html
+++ b/docs/0.9.0/usage/other_features/customizing_homepage.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/notebook_actions.html
+++ b/docs/0.9.0/usage/other_features/notebook_actions.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/personalized_mode.html
+++ b/docs/0.9.0/usage/other_features/personalized_mode.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/publishing_paragraphs.html
+++ b/docs/0.9.0/usage/other_features/publishing_paragraphs.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/other_features/zeppelin_context.html
+++ b/docs/0.9.0/usage/other_features/zeppelin_context.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/configuration.html
+++ b/docs/0.9.0/usage/rest_api/configuration.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/credential.html
+++ b/docs/0.9.0/usage/rest_api/credential.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/helium.html
+++ b/docs/0.9.0/usage/rest_api/helium.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/interpreter.html
+++ b/docs/0.9.0/usage/rest_api/interpreter.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/notebook.html
+++ b/docs/0.9.0/usage/rest_api/notebook.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/notebook_repository.html
+++ b/docs/0.9.0/usage/rest_api/notebook_repository.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/rest_api/zeppelin_server.html
+++ b/docs/0.9.0/usage/rest_api/zeppelin_server.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/zeppelin_sdk/client_api.html
+++ b/docs/0.9.0/usage/zeppelin_sdk/client_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 

--- a/docs/0.9.0/usage/zeppelin_sdk/session_api.html
+++ b/docs/0.9.0/usage/zeppelin_sdk/session_api.html
@@ -10,10 +10,6 @@
     <!-- Enable responsive viewport -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-    <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
 
     <link href="/docs/0.9.0/assets/themes/zeppelin/font-awesome.min.css" rel="stylesheet">
 


### PR DESCRIPTION
## Summary

- removes the obsolete html5shim external script block from generated docs and the active Zeppelin site template
- removes stale external-resource comments from the main site stylesheet
- makes the Medium controller tolerate the intentionally absent Medium feed data

## Validation

- node --check assets/themes/zeppelin/js/medium.controller.js
- git diff --check
- docker build -t zeppelin-site-dev:latest .
- docker run --rm -e JEKYLL_ENV=production -v "$PWD:/app" zeppelin-site-dev:latest bundle exec jekyll build
