### PR TITLE
Add manual ASF site promotion workflow

### DIFF
--- a/.github/workflows/promote-asf-staging.yml
+++ b/.github/workflows/promote-asf-staging.yml
@@ -1,0 +1,119 @@
+name: Promote ASF staging to site
+
+run-name: Promote asf-staging to asf-site by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Type "promote" to reset asf-site to asf-staging.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: promote-asf-site
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote asf-staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Guard manual promotion
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$REPOSITORY" != "apache/zeppelin-site" ]; then
+            echo "This workflow can only promote apache/zeppelin-site." >&2
+            exit 1
+          fi
+
+          if [ "$REF_NAME" != "master" ]; then
+            echo "Run this workflow from the master branch." >&2
+            exit 1
+          fi
+
+          if [ "$CONFIRM" != "promote" ]; then
+            echo 'Type "promote" in the confirm input to run this workflow.' >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch ASF site branches
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --prune origin \
+            refs/heads/asf-site:refs/remotes/origin/asf-site \
+            refs/heads/asf-staging:refs/remotes/origin/asf-staging
+
+          site_sha="$(git rev-parse origin/asf-site)"
+          staging_sha="$(git rev-parse origin/asf-staging)"
+          ahead_behind="$(git rev-list --left-right --count origin/asf-site...origin/asf-staging)"
+
+          {
+            echo "### Current refs"
+            echo
+            echo "- asf-site: \`$site_sha\`"
+            echo "- asf-staging: \`$staging_sha\`"
+            echo "- ahead/behind: \`$ahead_behind\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote asf-staging to asf-site
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          old_site="$(git rev-parse origin/asf-site)"
+          staging_sha="$(git rev-parse origin/asf-staging)"
+
+          if [ "$old_site" = "$staging_sha" ]; then
+            echo "asf-site is already aligned with asf-staging."
+            exit 0
+          fi
+
+          git switch -C asf-site origin/asf-site
+          git reset --hard "$staging_sha"
+          git push --force-with-lease=refs/heads/asf-site:"$old_site" origin HEAD:refs/heads/asf-site
+
+      - name: Verify promoted refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git ls-remote origin refs/heads/asf-site refs/heads/asf-staging | tee /tmp/asf-site-refs
+
+          site_remote="$(awk '$2 == "refs/heads/asf-site" { print $1 }' /tmp/asf-site-refs)"
+          staging_remote="$(awk '$2 == "refs/heads/asf-staging" { print $1 }' /tmp/asf-site-refs)"
+
+          if [ -z "$site_remote" ] || [ -z "$staging_remote" ]; then
+            echo "Unable to read both asf-site and asf-staging refs." >&2
+            exit 1
+          fi
+
+          if [ "$site_remote" != "$staging_remote" ]; then
+            echo "asf-site and asf-staging are not aligned after promotion." >&2
+            exit 1
+          fi
+
+          {
+            echo
+            echo "### Verified refs"
+            echo
+            echo "- asf-site: \`$site_remote\`"
+            echo "- asf-staging: \`$staging_remote\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Be extra careful with `asf-site` and `asf-staging`. The user cares about proof o
 - In the final response, include the exact pushed refspec or push output and the final `git ls-remote` result, so it is clear that `asf-site` moved and `asf-staging` did not.
 - After the manual `Promote ASF staging to site` GitHub Actions workflow is available on `master`, it can be used to promote an already-verified staged site instead of doing the local reset by hand:
   ```bash
-  gh workflow run promote-asf-staging.yml --ref master -f confirm=promote
+  gh workflow run promote-asf-staging.yml --repo apache/zeppelin-site --ref master -f confirm=promote
   ```
 - Use that workflow only after confirming `https://zeppelin.staged.apache.org` has the intended content. It fetches `asf-site` and `asf-staging`, pushes with `--force-with-lease`, and verifies both remote refs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,11 @@ Be extra careful with `asf-site` and `asf-staging`. The user cares about proof o
   git ls-remote origin refs/heads/asf-site refs/heads/asf-staging
   ```
 - In the final response, include the exact pushed refspec or push output and the final `git ls-remote` result, so it is clear that `asf-site` moved and `asf-staging` did not.
+- After the manual `Promote ASF staging to site` GitHub Actions workflow is available on `master`, it can be used to promote an already-verified staged site instead of doing the local reset by hand:
+  ```bash
+  gh workflow run promote-asf-staging.yml --ref master -f confirm=promote
+  ```
+- Use that workflow only after confirming `https://zeppelin.staged.apache.org` has the intended content. It fetches `asf-site` and `asf-staging`, pushes with `--force-with-lease`, and verifies both remote refs.
 
 ## Commit Hygiene
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ $ ./zeppelin-site.sh --build-dist
 
 **2. The built site will be available in the _site directory.**
 
+## Publish website
+
+ASF Infra builds `master` to the `asf-staging` branch according to `.asf.yaml`.
+After checking [https://zeppelin.staged.apache.org](https://zeppelin.staged.apache.org),
+committers with write access can manually promote the staged site to production:
+
+1. Open the `Promote ASF staging to site` workflow in GitHub Actions.
+2. Click `Run workflow` on the `master` branch.
+3. Type `promote` in the `confirm` input.
+4. Run the workflow.
+
+The workflow fetches `asf-site` and `asf-staging`, resets `asf-site` to
+`asf-staging`, pushes with `--force-with-lease`, and verifies that both remote
+branches point to the same commit.
 
 ## Troubleshooting and Notes:
 Ensure all dependencies are correctly listed and installed. 


### PR DESCRIPTION
## Summary
- Add a manual workflow_dispatch action that promotes `asf-staging` to `asf-site`.
- Require `confirm=promote`, the `master` branch, and the `apache/zeppelin-site` repository before promotion.
- Document the promotion flow in README.md and AGENTS.md.

## Validation
- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_file(ARGV.fetch(0)); puts "YAML syntax OK"' .github/workflows/promote-asf-staging.yml`

## Notes
- The workflow uses `--force-with-lease` and verifies that `asf-site` and `asf-staging` point to the same remote commit after the push.
